### PR TITLE
Sign Drone's CI configuration (to run on drone.grafana.net)

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -35,4 +35,8 @@ steps:
   depends_on:
   - download
 
+---
+kind: signature
+hmac: 27e9124f010ea02719fed325246799697d827ceb9dcf7d742fb30fb45372b728
+
 ...

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ uninstall:
 	go clean -i ./cmd/cuetsy
 
 # CI
+# Export environment variables from here: https://drone.grafana.net/account
+# Only Grafana employees can regenerate the CI configuration
+# A temp file is created to make sure the `sign` command succeeds
+# For more info: https://github.com/grafana/deployment_tools/blob/master/docs/infrastructure/drone/signing.md
 drone:
-	cue export ./.drone/drone.cue > .drone/drone.yml
-	drone fmt --save .drone/drone.yml
+	cue export ./.drone/drone.cue > .drone/drone.tmp.yml
+	drone fmt --save .drone/drone.tmp.yml
+	drone lint .drone/drone.tmp.yml
+	drone sign --save grafana/cuetsy .drone/drone.tmp.yml
+	mv .drone/drone.tmp.yml .drone/drone.yml


### PR DESCRIPTION
This is required for public repositories that run on our Drone instance