### PR TITLE
Nested Structure generation without defaults

### DIFF
--- a/encoder/templates.go
+++ b/encoder/templates.go
@@ -71,6 +71,17 @@ const {{ToLowerCamel .name}}Default: {{.name}} = {
 }{{end}}
 `)
 
+var nestedStructCode = tmpl("nestedstruct", `
+{{- if .maturity -}}
+/**
+ * {{.maturity}}
+ */
+{{end -}}
+{
+{{- range .pairs}}
+{{ range $.level}}  {{end}}  {{.K}}: {{.V}};{{end}}
+{{ range $.level}}  {{end}}}`)
+
 func tmpl(name, data string) *template.Template {
 	t := template.New(name)
 	t.Funcs(template.FuncMap{

--- a/encoder/tests/defaultsInterface
+++ b/encoder/tests/defaultsInterface
@@ -17,6 +17,14 @@ Foo: {
   I2_TypedList: ATypedList
 } @cuetsy(kind="interface")
 
+NestedFoo: {
+  Bar: string | *"ohai"
+  Foo: {
+    Bar: string | *"ohai"
+    Baz: AType
+  }
+} @cuetsy(kind="interface")
+
 -- ts  --
 export type AType = 'foo' | 'bar' | 'baz';
 export const aTypeDefault: AType = 'baz'
@@ -35,4 +43,14 @@ export const fooDefault: Foo = {
   C: aTypeDefault,
   I1_TypedList: [1, 2],
   I2_TypedList: aTypedListDefault,
+}
+export interface NestedFoo {
+  Bar: string;
+  Foo: {
+    Bar: string;
+    Baz: aTypeDefault;
+  };
+}
+export const nestedFooDefault: NestedFoo = {
+  Bar: 'ohai',
 }

--- a/encoder/tests/nestedStruct
+++ b/encoder/tests/nestedStruct
@@ -1,0 +1,62 @@
+Verifies expected behavior with basic nested structs
+
+-- cue --
+package cuetsy
+
+OneLevel: {
+  Foo: string
+  Bar: number
+} @cuetsy(kind="interface")
+
+TwoLevel: {
+    Outer: string
+    NestedDecl: {
+        InnerOne: number
+        InnerTwo: number
+    }
+} @cuetsy(kind="interface")
+
+ThreeLevel: {
+    Outer: string
+    NestedDecl1: {
+      InnerOne: number
+      InnerTwo: number
+      NestedDecl2: {
+        InnerOne: number
+        InnerTwo: number
+      }
+    }
+} @cuetsy(kind="interface")
+
+Composed: {
+    Outer: string
+    NestedRef: OneLevel
+} @cuetsy(kind="interface")
+
+-- ts --
+export interface OneLevel {
+  Bar: number;
+  Foo: string;
+}
+export interface TwoLevel {
+  NestedDecl: {
+    InnerOne: number;
+    InnerTwo: number;
+  };
+  Outer: string;
+}
+export interface ThreeLevel {
+  NestedDecl1: {
+    InnerOne: number;
+    InnerTwo: number;
+    NestedDecl2: {
+      InnerOne: number;
+      InnerTwo: number;
+    };
+  };
+  Outer: string;
+}
+export interface Composed {
+  NestedRef: OneLevel;
+  Outer: string;
+}


### PR DESCRIPTION
This PR is to generate the Nested Structure from cue to typescript. It doesn't fully support the default generation for the following case yet.
```
NestedFoo: {
  Bar: string | *"ohai"
  Foo: {
    Bar: string | *"ohai"
    Baz: AType
  }
} @cuetsy(kind="interface")
```
The expected result should be
```
export const nestedFooDefault: NestedFoo = {
  Bar: 'ohai',
  Foo: {
    Bar: 'ohai'
  }
}
```
instead of
```
export const nestedFooDefault: NestedFoo = {
  Bar: 'ohai',
}
```