### PR TITLE
Make `default` render after import subject

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -568,7 +568,10 @@ func tsPrintDefault(v cue.Value) (bool, string, error) {
 		}
 		result = dStr
 		if isReference(d) {
-			result = "default" + result
+			// FIXME this is just horrifingly coarse guessing, ugh we need an AST
+			parts := strings.Split(result, ".")
+			parts[len(parts)-1] = "default" + parts[len(parts)-1]
+			result = strings.Join(parts, ".")
 		}
 		return true, result, nil
 	}

--- a/testdata/imports/enum_defaults.txtar
+++ b/testdata/imports/enum_defaults.txtar
@@ -1,0 +1,55 @@
+-- cue.mod/module.cue --
+module: "example.com"
+
+-- one.cue --
+package test
+
+import "example.com/dep"
+
+Enum: "foo" | "bar" | *"baz" @cuetsy(kind="enum")
+EnumNumeric: *1 | 2 | 3 @cuetsy(kind="enum", memberNames="Foo|Bar|Zip")
+
+Ref: {
+  le: Enum
+  len: EnumNumeric
+  dle: dep.DepEnum
+  dlen: dep.DepEnumNumeric
+} @cuetsy(kind="interface")
+
+-- dep/file.cue --
+package dep
+
+DepEnum: "foo" | "bar" | *"baz" @cuetsy(kind="enum")
+DepEnumNumeric: *1 | 2 | 3 @cuetsy(kind="enum", memberNames="Foo|Bar|Zip")
+
+-- out/gen --
+
+export enum Enum {
+  Bar = 'bar',
+  Baz = 'baz',
+  Foo = 'foo',
+}
+
+export const defaultEnum: Enum = Enum.Baz;
+
+export enum EnumNumeric {
+  Bar = 2,
+  Foo = 1,
+  Zip = 3,
+}
+
+export const defaultEnumNumeric: EnumNumeric = EnumNumeric.Foo;
+
+export interface Ref {
+  dle: dep.DepEnum;
+  dlen: dep.DepEnumNumeric;
+  le: Enum;
+  len: EnumNumeric;
+}
+
+export const defaultRef: Ref = {
+  dle: dep.defaultDepEnum,
+  dlen: dep.defaultDepEnumNumeric,
+  le: defaultEnum,
+  len: defaultEnumNumeric,
+};


### PR DESCRIPTION
Previously, references to default values defined in a dependency had `default` prepended before the reference to the imported package - e.g., `defaultdepname.Object`. This fixes that to be `depname.defaultObject`.

Partial step towards addressing #35.