### PR TITLE
Add `forceText` attr to allow specifying output text type

### DIFF
--- a/testdata/imports/force_text.txtar
+++ b/testdata/imports/force_text.txtar
@@ -4,7 +4,7 @@ module: "example.com"
 -- one.cue --
 package test
 
-MyType: 1 | 2 @cuetsy(kind="enum",memberNames="A|B")
+MyType: 1 | 2 @cuetsy(kind="enum", memberNames="A|B")
 
 ModeOptions: ModeOptionsA | ModeOptionsB @cuetsy(kind="type")
 
@@ -19,19 +19,20 @@ ModeOptionsB: {
 } @cuetsy(kind="interface")
 
 -- out/gen --
+
 export enum MyType {
-    A = 1,
-    B = 2,
+  A = 1,
+  B = 2,
 }
 
 export type ModeOptions = ModeOptionsA | ModeOptionsB;
-​
+
 export interface ModeOptionsA {
-  type: MyType.A;
   aProp: boolean;
+  type: MyType.A;
 }
 
 export interface ModeOptionsB {
-  type: MyType.B;
   bProp: boolean;
+  type: MyType.B;
 }

--- a/testdata/imports/force_text.txtar
+++ b/testdata/imports/force_text.txtar
@@ -1,0 +1,37 @@
+-- cue.mod/module.cue --
+module: "example.com"
+
+-- one.cue --
+package test
+
+MyType: 1 | 2 @cuetsy(kind="enum",memberNames="A|B")
+
+ModeOptions: ModeOptionsA | ModeOptionsB @cuetsy(kind="type")
+
+ModeOptionsA: {
+  type: MyType & 1 @cuetsy(forceText="MyType.A")
+  aProp: bool
+} @cuetsy(kind="interface")
+
+ModeOptionsB: {
+  type: MyType & 2 @cuetsy(forceText="MyType.B")
+  bProp: bool
+} @cuetsy(kind="interface")
+
+-- out/gen --
+export enum MyType {
+    A = 1,
+    B = 2,
+}
+
+export type ModeOptions = ModeOptionsA | ModeOptionsB;
+​
+export interface ModeOptionsA {
+  type: MyType.A;
+  aProp: boolean;
+}
+
+export interface ModeOptionsB {
+  type: MyType.B;
+  bProp: boolean;
+}


### PR DESCRIPTION
This introduces a `@cuetsy(forceText="")` attribute, which allows the author to specify an exact string that cuetsy will just render through on translation.

This is the best current answer we have for problems stemming from #35, but a hack like this is quite likely to be useful on into the future as well as we run into other limitations.

It does make me a bit uncomfortable, but the fact that the generated typescript on the other side is almost certain to be checked...well, helps.