### PR TITLE
TypeScript AST

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	cuelang.org/go v0.4.0
 	github.com/google/go-cmp v0.5.5
+	github.com/matryer/is v1.4.0
 	github.com/rogpeppe/go-internal v1.8.0
 	golang.org/x/tools v0.0.0-20200612220849-54c614fe050c
 	gotest.tools v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
+github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/templates.go
+++ b/templates.go
@@ -60,8 +60,7 @@ var interfaceCode = tmpl("interface", `
 interface {{.name}}{{if ne (len .extends) 0}} extends {{ Join .extends ", "}}{{end}} {
   {{- range .pairs}}
   {{.K}}: {{.V}};{{end}}
-}
-{{- if .defaults }}
+}{{- if .defaults }}
 
 {{if .export}}export {{end -}}
 const default{{.name}}: {{.name}} = {

--- a/templates.go
+++ b/templates.go
@@ -21,8 +21,7 @@ type {{.name}} = {{ Join .tokens " | "}};
 {{- if .default }}
 
 {{if .export}}export {{end -}}
-const default{{.name}}: {{.name}} = {{.default}};{{end}}
-`)
+const default{{.name}}: {{.name}} = {{.default}};{{end}}`)
 
 // Generate a typescript enum declaration. Inputs:
 // .maturity	Optional. Maturity level, applied in doc comment
@@ -43,8 +42,7 @@ enum {{.name}} {
 {{- if .default }}
 
 {{if .export}}export {{end -}}
-const default{{.name}}: {{.name}} = {{.name}}.{{.default}};{{end}}
-`)
+const default{{.name}}: {{.name}} = {{.name}}.{{.default}};{{end}}`)
 
 // Generate a typescript interface declaration. Inputs:
 // .maturity	Optional. Maturity level, applied in doc comment
@@ -69,8 +67,7 @@ interface {{.name}}{{if ne (len .extends) 0}} extends {{ Join .extends ", "}}{{e
 const default{{.name}}: {{.name}} = {
   {{- range .pairs}}{{if .Default}}
   {{StripQ .K}}: {{.Default}},{{end}}{{end}}
-};{{end}}
-`)
+};{{end}}`)
 
 var nestedStructCode = tmpl("nestedstruct", `{
 {{- range .pairs}}

--- a/ts/ast/ast.go
+++ b/ts/ast/ast.go
@@ -1,0 +1,188 @@
+package ast
+
+import (
+	"fmt"
+	"strings"
+)
+
+const Indent = "  "
+
+type File struct {
+	Nodes []Node
+}
+
+func (f File) String() string {
+	var b strings.Builder
+
+	for _, n := range f.Nodes {
+		b.WriteString(n.String())
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+type Node interface {
+	fmt.Stringer
+}
+
+type Expr interface {
+	Node
+	expr()
+}
+
+var (
+	_ Expr = SelectorExpr{}
+	_ Expr = IndexExpr{}
+	_ Expr = Num{}
+)
+
+type Raw struct {
+	Data string
+}
+
+func (r Raw) expr() {}
+func (r Raw) String() string {
+	return r.Data
+}
+
+type Ident struct {
+	Name string
+}
+
+func (i Ident) expr() {}
+func (i Ident) String() string {
+	return i.Name
+}
+
+func None() Expr {
+	return Ident{}
+}
+
+type SelectorExpr struct {
+	Expr Expr
+	Sel  Ident
+}
+
+func (s SelectorExpr) expr() {}
+func (s SelectorExpr) String() string {
+	return fmt.Sprintf("%s.%s", s.Expr, s.Sel)
+}
+
+type IndexExpr struct {
+	Expr  Expr
+	Index Expr
+}
+
+func (i IndexExpr) expr() {}
+func (i IndexExpr) String() string {
+	return fmt.Sprintf("%s[%s]", i.Expr, i.Index)
+}
+
+type AssignExpr struct {
+	Name  Ident
+	Value Expr
+}
+
+func (a AssignExpr) expr() {}
+func (a AssignExpr) String() string {
+	return fmt.Sprintf("%s = %s", a.Name, a.Value)
+}
+
+type KeyValueExpr struct {
+	Key   Expr
+	Value Expr
+}
+
+func (k KeyValueExpr) expr() {}
+func (k KeyValueExpr) String() string {
+	return fmt.Sprintf("%s: %s", k.Key, k.Value)
+}
+
+type UnaryExpr struct {
+	Op   string // operator
+	Expr Expr   // operand
+}
+
+func (u UnaryExpr) expr() {}
+func (u UnaryExpr) String() string {
+	return u.Op + u.Expr.String()
+}
+
+type Num struct {
+	N   interface{}
+	Fmt string
+}
+
+func (n Num) expr() {}
+func (n Num) String() string {
+	if n.Fmt == "" {
+		return fmt.Sprintf("%v", n.N)
+	}
+	return fmt.Sprintf(n.Fmt, n.N)
+}
+
+type Str struct {
+	Value string
+}
+
+func (s Str) expr() {}
+func (s Str) String() string {
+	return fmt.Sprintf(`'%s'`, s.Value)
+}
+
+type Type interface {
+	Node
+	typeName() string
+}
+
+var (
+	_ Type = EnumType{}
+	_ Type = InterfaceType{}
+)
+
+type TypeDecl struct {
+	Name Ident
+	Type Type
+}
+
+func (t TypeDecl) String() string {
+	return fmt.Sprintf("%s %s %s", t.Type.typeName(), t.Name, t.Type)
+}
+
+type EnumType struct {
+	Elems []Expr
+}
+
+func (e EnumType) typeName() string { return "enum" }
+func (e EnumType) String() string {
+	var b strings.Builder
+	b.WriteString("{")
+	if len(e.Elems) > 0 {
+		b.WriteString("\n")
+	}
+	for _, e := range e.Elems {
+		b.WriteString(Indent)
+		b.WriteString(e.String())
+		b.WriteString(",\n")
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+type InterfaceType struct {
+	Elems []KeyValueExpr
+}
+
+func (i InterfaceType) typeName() string { return "interface" }
+func (i InterfaceType) String() string {
+	var b strings.Builder
+	b.WriteString("{\n")
+	for _, e := range i.Elems {
+		b.WriteString(Indent)
+		b.WriteString(e.String())
+		b.WriteString("\n")
+	}
+	b.WriteString("}")
+	return b.String()
+}

--- a/ts/ast/ast_test.go
+++ b/ts/ast/ast_test.go
@@ -1,0 +1,101 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/grafana/cuetsy/ts/ast"
+	"github.com/matryer/is"
+)
+
+func TestSelectorExpr(t *testing.T) {
+	is := is.New(t)
+
+	expr := ast.SelectorExpr{
+		Expr: ast.Ident{"foo"},
+		Sel:  ast.Ident{"bar"},
+	}
+	is.Equal("foo.bar", expr.String())
+
+	expr = ast.SelectorExpr{
+		Expr: ast.SelectorExpr{
+			Expr: ast.Ident{"foo"},
+			Sel:  ast.Ident{"bar"},
+		},
+		Sel: ast.Ident{"baz"},
+	}
+	is.Equal("foo.bar.baz", expr.String())
+}
+
+func TestIndexExpr(t *testing.T) {
+	is := is.New(t)
+
+	expr := ast.IndexExpr{
+		Expr:  ast.Ident{"foo"},
+		Index: ast.Num{N: 3},
+	}
+	is.Equal(expr.String(), "foo[3]")
+}
+
+func TestNum(t *testing.T) {
+	is := is.New(t)
+
+	is.Equal("0", ast.Num{N: 0}.String())
+	is.Equal("-12", ast.Num{N: -12}.String())
+	is.Equal("8", ast.Num{N: 8}.String())
+
+	is.Equal("0.12", ast.Num{N: 0.12}.String())
+	is.Equal("312", ast.Num{N: 3.12e2}.String())
+	is.Equal("3.120000e+02", ast.Num{N: 3.12e2, Fmt: "%e"}.String())
+}
+
+func TestAssignExpr(t *testing.T) {
+	is := is.New(t)
+
+	expr := ast.AssignExpr{
+		Name:  ast.Ident{"foo"},
+		Value: ast.Num{N: 4},
+	}
+	is.Equal("foo = 4", expr.String())
+}
+
+func TestKeyValueExpr(t *testing.T) {
+	is := is.New(t)
+
+	expr := ast.KeyValueExpr{
+		Key:   ast.Ident{"foo"},
+		Value: ast.Str{"bar"},
+	}
+	is.Equal("foo: 'bar'", expr.String())
+
+	expr = ast.KeyValueExpr{
+		Key: ast.IndexExpr{
+			Expr:  ast.Ident{""},
+			Index: ast.Str{"bar"},
+		},
+		Value: ast.Str{"baz"},
+	}
+	is.Equal("['bar']: 'baz'", expr.String())
+}
+
+func TestEnumType(t *testing.T) {
+	is := is.New(t)
+
+	T := ast.EnumType{
+		Elems: []ast.Expr{},
+	}
+	is.Equal("{}", T.String())
+
+	T = ast.EnumType{
+		Elems: []ast.Expr{
+			ast.AssignExpr{Name: ast.Ident{"foo"}, Value: ast.Num{N: 1}},
+			ast.Ident{"bar"},
+			ast.Ident{"baz"},
+		},
+	}
+	want := `{
+  foo = 1,
+  bar,
+  baz,
+}`
+	is.Equal(want, T.String())
+}

--- a/ts/ts.go
+++ b/ts/ts.go
@@ -6,3 +6,23 @@ type (
 	File = ast.File
 	Node = ast.Node
 )
+
+func Union(elems ...ast.Expr) ast.Expr {
+	switch len(elems) {
+	case 0:
+		return nil
+	case 1:
+		return elems[0]
+	}
+
+	var U ast.Expr = elems[0]
+	for _, e := range elems[1:] {
+		U = ast.BinaryExpr{
+			Op: "|",
+			X:  U,
+			Y:  e,
+		}
+	}
+
+	return U
+}

--- a/ts/ts.go
+++ b/ts/ts.go
@@ -1,0 +1,8 @@
+package ts
+
+import "github.com/grafana/cuetsy/ts/ast"
+
+type (
+	File = ast.File
+	Node = ast.Node
+)

--- a/ts/ts.go
+++ b/ts/ts.go
@@ -1,11 +1,20 @@
 package ts
 
-import "github.com/grafana/cuetsy/ts/ast"
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/grafana/cuetsy/ts/ast"
+)
 
 type (
 	File = ast.File
 	Node = ast.Node
 )
+
+func Ident(name string) ast.Ident {
+	return ast.Ident{Name: name}
+}
 
 func Union(elems ...ast.Expr) ast.Expr {
 	switch len(elems) {
@@ -25,4 +34,18 @@ func Union(elems ...ast.Expr) ast.Expr {
 	}
 
 	return U
+}
+
+func Export(decl ast.Decl) ast.Node {
+	return ast.ExportStmt{Decl: decl}
+}
+
+func Raw(data string) ast.Raw {
+	pc, file, no, ok := runtime.Caller(1)
+	details := runtime.FuncForPC(pc)
+	if ok && details != nil {
+		fmt.Printf("fix: ts.Raw used by %s at %s#%d\n", details.Name(), file, no)
+	}
+
+	return ast.Raw{Data: data}
 }


### PR DESCRIPTION
Introduces a (printing only) TypeScript AST and refactors the generator to use it:

- `ts/ast`: structs with `String()` methods for printing what they represent
- `ts`: higher level package, things like `Union` for generating a union type. Not heavily used yet.
- loosely inspired by the `go/ast` internals