### PR TITLE
ts/ast: ImportSpec

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -123,7 +123,7 @@ func execGetString(t *template.Template, data interface{}) (string, error) {
 	return result, nil
 }
 
-func (g *generator) decl(name string, v cue.Value) []ts.Node {
+func (g *generator) decl(name string, v cue.Value) []ts.Decl {
 	if !gast.IsExported(name) {
 		return nil
 	}
@@ -164,7 +164,7 @@ func (g *generator) decl(name string, v cue.Value) []ts.Node {
 	}
 }
 
-func (g *generator) genType(name string, v cue.Value) []ts.Node {
+func (g *generator) genType(name string, v cue.Value) []ts.Decl {
 	var tokens []tsast.Expr
 	// If there's an AndOp first, pass through it.
 	op, dvals := v.Expr()
@@ -201,7 +201,7 @@ func (g *generator) genType(name string, v cue.Value) []ts.Node {
 
 	d, ok := v.Default()
 	if !ok {
-		return []ts.Node{T}
+		return []ts.Decl{T}
 	}
 
 	dStr, err := tsprintField(d, 0)
@@ -215,7 +215,7 @@ func (g *generator) genType(name string, v cue.Value) []ts.Node {
 		},
 	)
 
-	return []ts.Node{T, D}
+	return []ts.Decl{T, D}
 }
 
 type KV struct {
@@ -226,7 +226,7 @@ type KV struct {
 // - value disjunction (a | b | c): values are taken as attribut memberNames,
 //   if memberNames is absent, then keys implicitely generated as CamelCase
 // - string struct: struct keys get enum keys, struct values enum values
-func (g *generator) genEnum(name string, v cue.Value) []ts.Node {
+func (g *generator) genEnum(name string, v cue.Value) []ts.Decl {
 	// FIXME compensate for attribute-applying call to Unify() on incoming Value
 	op, dvals := v.Expr()
 	if op == cue.AndOp {
@@ -273,7 +273,7 @@ func (g *generator) genEnum(name string, v cue.Value) []ts.Node {
 	)
 
 	if defaultValue == "" {
-		return []ts.Node{T}
+		return []ts.Decl{T}
 	}
 
 	D := ts.Export(
@@ -283,7 +283,7 @@ func (g *generator) genEnum(name string, v cue.Value) []ts.Node {
 			Value: tsast.SelectorExpr{Expr: ts.Ident(name), Sel: ts.Ident(defaultValue)},
 		},
 	)
-	return []ts.Node{T, D}
+	return []ts.Decl{T, D}
 }
 
 func getDefaultValue(v cue.Value) (string, error) {
@@ -364,7 +364,7 @@ func genOrEnum(v cue.Value) ([]KV, error) {
 	return pairs, nil
 }
 
-func (g *generator) genInterface(name string, v cue.Value) []ts.Node {
+func (g *generator) genInterface(name string, v cue.Value) []ts.Decl {
 	// We restrict the derivation of Typescript interfaces to struct kinds.
 	// (More than just a struct literal match this, though.)
 	if v.IncompleteKind() != cue.StructKind {
@@ -567,7 +567,7 @@ func (g *generator) genInterface(name string, v cue.Value) []ts.Node {
 	)
 
 	if len(defs) == 0 {
-		return []ts.Node{T}
+		return []ts.Decl{T}
 	}
 
 	D := ts.Export(
@@ -578,7 +578,7 @@ func (g *generator) genInterface(name string, v cue.Value) []ts.Node {
 		},
 	)
 
-	return []ts.Node{T, D}
+	return []ts.Decl{T, D}
 }
 
 func tsPrintDefault(v cue.Value) (bool, string, error) {

--- a/ts/ast/ast_test.go
+++ b/ts/ast/ast_test.go
@@ -7,21 +7,25 @@ import (
 	"github.com/matryer/is"
 )
 
+func ident(s string) ast.Ident {
+	return ast.Ident{Name: s}
+}
+
 func TestSelectorExpr(t *testing.T) {
 	is := is.New(t)
 
 	expr := ast.SelectorExpr{
-		Expr: ast.Ident{"foo"},
-		Sel:  ast.Ident{"bar"},
+		Expr: ident("foo"),
+		Sel:  ident("bar"),
 	}
 	is.Equal("foo.bar", expr.String())
 
 	expr = ast.SelectorExpr{
 		Expr: ast.SelectorExpr{
-			Expr: ast.Ident{"foo"},
-			Sel:  ast.Ident{"bar"},
+			Expr: ident("foo"),
+			Sel:  ident("bar"),
 		},
-		Sel: ast.Ident{"baz"},
+		Sel: ident("baz"),
 	}
 	is.Equal("foo.bar.baz", expr.String())
 }
@@ -30,7 +34,7 @@ func TestIndexExpr(t *testing.T) {
 	is := is.New(t)
 
 	expr := ast.IndexExpr{
-		Expr:  ast.Ident{"foo"},
+		Expr:  ident("foo"),
 		Index: ast.Num{N: 3},
 	}
 	is.Equal(expr.String(), "foo[3]")
@@ -52,7 +56,7 @@ func TestAssignExpr(t *testing.T) {
 	is := is.New(t)
 
 	expr := ast.AssignExpr{
-		Name:  ast.Ident{"foo"},
+		Name:  ident("foo"),
 		Value: ast.Num{N: 4},
 	}
 	is.Equal("foo = 4", expr.String())
@@ -62,14 +66,14 @@ func TestKeyValueExpr(t *testing.T) {
 	is := is.New(t)
 
 	expr := ast.KeyValueExpr{
-		Key:   ast.Ident{"foo"},
+		Key:   ident("foo"),
 		Value: ast.Str{"bar"},
 	}
 	is.Equal("foo: 'bar'", expr.String())
 
 	expr = ast.KeyValueExpr{
 		Key: ast.IndexExpr{
-			Expr:  ast.Ident{""},
+			Expr:  ident(""),
 			Index: ast.Str{"bar"},
 		},
 		Value: ast.Str{"baz"},
@@ -87,9 +91,9 @@ func TestEnumType(t *testing.T) {
 
 	T = ast.EnumType{
 		Elems: []ast.Expr{
-			ast.AssignExpr{Name: ast.Ident{"foo"}, Value: ast.Num{N: 1}},
-			ast.Ident{"bar"},
-			ast.Ident{"baz"},
+			ast.AssignExpr{Name: ident("foo"), Value: ast.Num{N: 1}},
+			ident("bar"),
+			ident("baz"),
 		},
 	}
 	want := `{

--- a/ts/ast/lit.go
+++ b/ts/ast/lit.go
@@ -1,0 +1,38 @@
+package ast
+
+import "strings"
+
+type DestrLit struct {
+	Brack  Brack
+	Idents []Ident
+}
+
+func (d DestrLit) ident() {}
+func (d DestrLit) String() string {
+	idStrs := make([]string, len(d.Idents))
+	for i, d := range d.Idents {
+		idStrs[i] = d.String()
+	}
+
+	return string(d.Brack[0]) + strings.Join(idStrs, ", ") + string(d.Brack[1])
+}
+
+type ObjectLit struct {
+	Elems []KeyValueExpr
+}
+
+func (o ObjectLit) expr() {}
+func (o ObjectLit) String() string {
+	var b strings.Builder
+	b.WriteString("{\n")
+	for _, e := range o.Elems {
+		b.WriteString(Indent)
+		b.WriteString(e.String())
+		b.WriteString(",\n")
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+// TODO: combine InterfaceType, EnumType and ObjectLit rendering into below
+// type CompositeLit struct {}

--- a/ts/ts.go
+++ b/ts/ts.go
@@ -10,6 +10,7 @@ import (
 type (
 	File = ast.File
 	Node = ast.Node
+	Decl = ast.Decl
 )
 
 func Ident(name string) ast.Ident {
@@ -36,7 +37,7 @@ func Union(elems ...ast.Expr) ast.Expr {
 	return U
 }
 
-func Export(decl ast.Decl) ast.Node {
+func Export(decl ast.Decl) ast.Decl {
 	return ast.ExportStmt{Decl: decl}
 }
 


### PR DESCRIPTION
Introduces the `ast.ImportSpec` type, which represents import statements
of the following forms:

   import foo from "bar";
   import {foo, bar} from "baz";
   import * as foo from "bar";
   import {foo as bar} from "baz";

As a side-effect, `ast.File` now expects `ast.Decl` instead of
`ast.Node` at the top level, to prevent mixing imports (which are not
declarations on purpose) with the actual elements.