### PR TITLE
Add support for generating regexes

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -1072,6 +1072,10 @@ func tsprintField(v cue.Value) (ts.Expr, error) {
 		//
 		// TODO get more certainty/a clearer way of ascertaining this
 		switch op {
+		case cue.RegexMatchOp:
+			// Typescript has no native type for representing regexes. Only
+			// option is to fall back to string.
+			return tsprintType(cue.StringKind), nil
 		case cue.NoOp, cue.OrOp, cue.AndOp:
 		default:
 			return nil, valError(v, "bounds constraints are not supported as they lack a direct typescript equivalent")

--- a/generator.go
+++ b/generator.go
@@ -236,7 +236,7 @@ func (g *generator) genType(name string, v cue.Value) []ts.Decl {
 			}
 			tokens = append(tokens, tok)
 		}
-	case cue.NoOp:
+	case cue.NoOp, cue.RegexMatchOp:
 		tok, err := tsprintField(v)
 		if err != nil {
 			g.addErr(err)

--- a/testdata/imports/regex.txtar
+++ b/testdata/imports/regex.txtar
@@ -1,0 +1,20 @@
+-- cue.mod/module.cue --
+module: "example.com"
+
+-- one.cue --
+package test
+
+Top: =~"^([0-9]+)(\\.[0-9x]+)?(\\.[0-9x])?$" | *"0.x.x" @cuetsy(kind="type")
+Inside: {
+    inner: =~"^[0-9a-z]+\\-([0-9a-z]+\\-)"
+} @cuetsy(kind="interface")
+
+-- out/gen --
+
+export type Top = string;
+
+export const defaultTop: Top = '0.x.x';
+
+export interface Inside {
+  inner: string;
+}


### PR DESCRIPTION
We don't currently support CUE regex kinds. There's no corresponding support on the TypeScript side (proposal here https://github.com/microsoft/TypeScript/issues/41160), so this simple fix just lets us fall back to strings.

TODO some tests