### PR TITLE
Map bytes to string

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -1057,6 +1057,8 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 		fallthrough
 	case cue.TopKind:
 		return tsprintType(ik), nil
+	case cue.BytesKind:
+		return tsprintType(cue.StringKind), nil
 	}
 
 	// Having more than one possible kind entails a disjunction, TopKind, or

--- a/testdata/bytes_to_string.txtar
+++ b/testdata/bytes_to_string.txtar
@@ -1,0 +1,12 @@
+-- one.cue --
+package cuetsy
+
+ByteToString: {
+    value: bytes
+} @cuetsy(kind="interface")
+
+-- out/gen --
+
+export interface ByteToString {
+  value: string;
+}


### PR DESCRIPTION
If we add `bytes` in a schema, it should render `[]byte` for Go and `string` for Ts. `bytes` doesn't exist in Ts and the file generation fails.

Fixes: https://github.com/grafana/schematization-and-as-code-project/issues/30