### PR TITLE
Map [string]: ? into their correct Result<string, ?>

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -909,11 +909,23 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 	case cue.StructKind:
 		switch op {
 		case cue.SelectorOp, cue.AndOp, cue.NoOp:
+			val := v.LookupPath(cue.MakePath(cue.AnyString))
+			if val.Exists() {
+				kvs := []tsast.KeyValueExpr{
+					{
+						Key:         ts.Ident("string"),
+						Value:       tsprintType(val.IncompleteKind()),
+						CommentList: commentsFor(val.Value(), true),
+					},
+				}
+
+				return tsast.ObjectLit{Elems: kvs, IsType: isType, IsMap: true}, nil
+			}
+
 			iter, err := v.Fields(cue.Optional(true))
 			if err != nil {
 				return nil, valError(v, "something went wrong when generate nested structs")
 			}
-
 			size, _ := v.Len().Int64()
 			kvs := make([]tsast.KeyValueExpr, 0, size)
 			for iter.Next() {

--- a/testdata/map_to_type.txtar
+++ b/testdata/map_to_type.txtar
@@ -1,0 +1,16 @@
+-- cue --
+package cuetsy
+
+Map: {
+  boolTest: [string]: bool
+  numberTest: [string]: int64
+  stringTest: [string]: string
+} @cuetsy(kind="interface")
+
+-- ts  --
+
+export interface Map {
+  boolTest: Record<string, boolean>;
+  numberTest: Record<string, number>;
+  stringTest: Record<string, string>;
+}

--- a/ts/ast/lit.go
+++ b/ts/ast/lit.go
@@ -10,6 +10,7 @@ type ObjectLit struct {
 	Comment []Comment
 	Elems   []KeyValueExpr
 	IsType  bool
+	IsMap   bool
 
 	eol EOL
 	lvl int
@@ -34,6 +35,12 @@ func (o ObjectLit) innerString(aeol EOL, lvl int) string {
 	write := b.WriteString
 	indent := func(n int) {
 		write(strings.Repeat(Indent, n))
+	}
+
+	if o.IsMap {
+		kv := o.Elems[0]
+		write(fmt.Sprintf("Record<%s, %s>", kv.Key.String(), kv.Value.String()))
+		return b.String()
 	}
 
 	if len(o.Elems) == 0 {


### PR DESCRIPTION
It maps maps values into their correct Result. Works for:

* `[string]: bool` --> `Result<string, boolean>`
* `[string]: string` --> `Result<string, string>`
* `[string]: int64 | float32` --> `Result<string, number>`

For non-string maps, we need to investigate and iterate it again. So maps like `map[in64]: ?` are still generating the `Result<string, unknown>` result.