### PR TITLE
Allow multiple types string map

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -911,16 +911,20 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 	case cue.StructKind:
 		switch op {
 		case cue.SelectorOp, cue.AndOp, cue.NoOp:
+			// Checks [string]something
 			val := v.LookupPath(cue.MakePath(cue.AnyString))
 			if val.Exists() {
+				expr, err := tsprintField(val, isType)
+				if err != nil {
+					return nil, valError(v, err.Error())
+				}
 				kvs := []tsast.KeyValueExpr{
 					{
 						Key:         ts.Ident("string"),
-						Value:       tsprintType(val.IncompleteKind()),
+						Value:       expr,
 						CommentList: commentsFor(val.Value(), true),
 					},
 				}
-
 				return tsast.ObjectLit{Elems: kvs, IsType: isType, IsMap: true}, nil
 			}
 

--- a/generator.go
+++ b/generator.go
@@ -911,7 +911,7 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 	case cue.StructKind:
 		switch op {
 		case cue.SelectorOp, cue.AndOp, cue.NoOp:
-			// Checks [string]something
+			// Checks [string]something and {...}
 			val := v.LookupPath(cue.MakePath(cue.AnyString))
 			if val.Exists() {
 				expr, err := tsprintField(val, isType)

--- a/generator.go
+++ b/generator.go
@@ -1122,7 +1122,7 @@ func tsprintType(k cue.Kind) ts.Expr {
 	case cue.NumberKind, cue.FloatKind, cue.IntKind:
 		return ts.Ident("number")
 	case cue.TopKind:
-		return ts.Ident("any")
+		return ts.Ident("unknown")
 	default:
 		return nil
 	}

--- a/testdata/interfaces.txtar
+++ b/testdata/interfaces.txtar
@@ -55,7 +55,7 @@ export enum E2 {
 export interface I1 {
   I1_FloatLiteral: 4.4;
   I1_OptionalDisjunctionLiteral?: ('other' | 'values' | 2);
-  I1_Top: any;
+  I1_Top: unknown;
 }
 
 export interface I2 {

--- a/testdata/map_to_type.txtar
+++ b/testdata/map_to_type.txtar
@@ -1,16 +1,36 @@
 -- cue --
 package cuetsy
 
+#StructTest: {
+  a: string
+}
+
 Map: {
   boolTest: [string]: bool
   numberTest: [string]: int64
   stringTest: [string]: string
+  emptyStructTest: {...}
+  listTest: [string]: [...string]
+  listWithStructTest: [string]: [...#StructTest]
+  mapTest: [string]: [string]: string
+  structTest: [string]: #StructTest
 } @cuetsy(kind="interface")
+
+
 
 -- ts  --
 
 export interface Map {
   boolTest: Record<string, boolean>;
+  emptyStructTest: Record<string, any>;
+  listTest: Record<string, Array<string>>;
+  listWithStructTest: Record<string, Array<{
+  a: string,
+}>>;
+  mapTest: Record<string, Record<string, string>>;
   numberTest: Record<string, number>;
   stringTest: Record<string, string>;
+  structTest: Record<string, {
+  a: string,
+}>;
 }

--- a/testdata/map_to_type.txtar
+++ b/testdata/map_to_type.txtar
@@ -14,6 +14,7 @@ Map: {
   listWithStructTest: [string]: [...#StructTest]
   mapTest: [string]: [string]: string
   structTest: [string]: #StructTest
+  optionalTest?: [string]: string
 } @cuetsy(kind="interface")
 
 
@@ -29,6 +30,7 @@ export interface Map {
 }>>;
   mapTest: Record<string, Record<string, string>>;
   numberTest: Record<string, number>;
+  optionalTest?: Record<string, string>;
   stringTest: Record<string, string>;
   structTest: Record<string, {
   a: string,

--- a/testdata/map_to_type.txtar
+++ b/testdata/map_to_type.txtar
@@ -22,7 +22,7 @@ Map: {
 
 export interface Map {
   boolTest: Record<string, boolean>;
-  emptyStructTest: Record<string, any>;
+  emptyStructTest: Record<string, unknown>;
   listTest: Record<string, Array<string>>;
   listWithStructTest: Record<string, Array<{
   a: string,


### PR DESCRIPTION
Its a fix of the previous fix 🙃. Instead of put the value directly checking `v.IncompleteKind()`, we call `tsprintField` again to get the proper Expr of the value.