### PR TITLE
Skip TopKind in maps

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -913,7 +913,7 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 		case cue.SelectorOp, cue.AndOp, cue.NoOp:
 			// Checks [string]something and {...}
 			val := v.LookupPath(cue.MakePath(cue.AnyString))
-			if val.Exists() {
+			if val.Exists() && val.IncompleteKind() != cue.TopKind {
 				expr, err := tsprintField(val, isType)
 				if err != nil {
 					return nil, valError(v, err.Error())

--- a/generator.go
+++ b/generator.go
@@ -911,7 +911,8 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 	case cue.StructKind:
 		switch op {
 		case cue.SelectorOp, cue.AndOp, cue.NoOp:
-			// Checks [string]something and {...}
+			// Checks [string]something only.
+			// It skips structs like {...} (cue.TopKind) to avoid undesired results.
 			val := v.LookupPath(cue.MakePath(cue.AnyString))
 			if val.Exists() && val.IncompleteKind() != cue.TopKind {
 				expr, err := tsprintField(val, isType)
@@ -1122,7 +1123,7 @@ func tsprintType(k cue.Kind) ts.Expr {
 	case cue.NumberKind, cue.FloatKind, cue.IntKind:
 		return ts.Ident("number")
 	case cue.TopKind:
-		return ts.Ident("unknown")
+		return ts.Ident("any")
 	default:
 		return nil
 	}

--- a/testdata/array_with_structs.txtar
+++ b/testdata/array_with_structs.txtar
@@ -2,7 +2,7 @@
 package cuetsy
 
 List: {
-  test?: [...(#StructTest | #DefinedStructTest)]  @grafanamaturity(NeedsExpertReview)
+  test?: [...(#StructTest | #DefinedStructTest)]
 
   #StructTest: {
     a: string

--- a/testdata/array_with_structs.txtar
+++ b/testdata/array_with_structs.txtar
@@ -1,0 +1,29 @@
+-- cue --
+package cuetsy
+
+List: {
+  test?: [...(#StructTest | #DefinedStructTest)]  @grafanamaturity(NeedsExpertReview)
+
+  #StructTest: {
+    a: string
+  }
+
+  #DefinedStructTest: {
+    type: "hola"
+    ...
+  }
+} @cuetsy(kind="interface")
+
+-- ts --
+
+export interface List {
+  test?: Array<({
+    a: string;
+  } | {
+      type: 'hola';
+    })>;
+}
+
+export const defaultList: Partial<List> = {
+  test: [],
+};

--- a/testdata/interfaces.txtar
+++ b/testdata/interfaces.txtar
@@ -55,7 +55,7 @@ export enum E2 {
 export interface I1 {
   I1_FloatLiteral: 4.4;
   I1_OptionalDisjunctionLiteral?: ('other' | 'values' | 2);
-  I1_Top: unknown;
+  I1_Top: any;
 }
 
 export interface I2 {

--- a/testdata/map_to_type.txtar
+++ b/testdata/map_to_type.txtar
@@ -5,6 +5,11 @@ package cuetsy
   a: string
 }
 
+#StructWithDots: {
+  type: "hola"
+  ...
+}
+
 Map: {
   boolTest: [string]: bool
   numberTest: [string]: int64
@@ -15,6 +20,8 @@ Map: {
   mapTest: [string]: [string]: string
   structTest: [string]: #StructTest
   optionalTest?: [string]: string
+  emptyStructMapTest: [string]: {...}
+  structWithDotsTest: [string]: #StructWithDots
 } @cuetsy(kind="interface")
 
 
@@ -23,6 +30,7 @@ Map: {
 
 export interface Map {
   boolTest: Record<string, boolean>;
+  emptyStructMapTest: Record<string, Record<string, unknown>>;
   emptyStructTest: Record<string, unknown>;
   listTest: Record<string, Array<string>>;
   listWithStructTest: Record<string, Array<{
@@ -34,5 +42,8 @@ export interface Map {
   stringTest: Record<string, string>;
   structTest: Record<string, {
   a: string,
+}>;
+  structWithDotsTest: Record<string, {
+  type: 'hola',
 }>;
 }


### PR DESCRIPTION
I was testing v0.1.3 with our current cue files and I saw the following:

```cue
panels: [...(#Panel | #GraphPanel | #HeatmapPanel)] @grafanamaturity(NeedsExpertReview)
```

was generating:

```ts
panels?: Array<(Panel | RowPanel | {
    type: 'graph';
  } | {
    type: 'heatmap';
})>;
```

with 0.1.3:
```ts
panels?: Array<(Panel | Record<string, unknown> | Record<string, unknown>)>;
```

And its not right.

The issue came because `GraphPanel` and `HeatmapPanel` are structs with data like:

```cue
#Something: {
  foo: "bar"
  ...
}
```

These structs are detected as maps, their kind is `cue.TopKind` and we set `unknown`. So if we skip them, we can generate the proper value without losing information.

Note: I back `any` as default in TopKind kind. When we detect an empty `{...}` the writer is going to print `Result<string, unknown>` like it was doing before.