### PR TITLE
Fix enum reference

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -788,6 +788,16 @@ func (g *generator) genEnumReference(v cue.Value) (*typeRef, error) {
 		if err != nil {
 			panic(err)
 		}
+		op, expr := v.Expr()
+		if len(expr) > 1 && expr[0].Kind() == cue.BottomKind && op == cue.SelectorOp {
+			val, err := expr[1].String()
+			if err != nil {
+				return nil, err
+			}
+			if ref.T.String() != val {
+				ref.T = ts.Raw(strings.Join([]string{ref.T.String(), val}, "."))
+			}
+		}
 	}
 
 	// Either specify a default if one exists (one conjunct), or rewrite the type to

--- a/testdata/enum.txtar
+++ b/testdata/enum.txtar
@@ -6,6 +6,10 @@ E2: "e2str1" | "e2str2" | "e2str3" | "e2str4" @cuetsy(kind="enum")
 E3: "e1str1" | "e1str2" | "e1str3" @cuetsy(kind="enum", memberNames="Foo|Bar|Zip")
 E4: 1 | 2 | 3 @cuetsy(kind="enum", memberNames="foo|Bar|Zip")
 
+ValueWithEnum: {
+  value: E1.E1str1
+} @cuetsy(kind="interface")
+
 -- ts  --
 
 export enum E1 {
@@ -31,4 +35,8 @@ export enum E4 {
   Bar = 2,
   Zip = 3,
   foo = 1,
+}
+
+export interface ValueWithEnum {
+  value: E1.E1str1;
 }


### PR DESCRIPTION
When we reference an enum value, `cuetsy` was setting only the enum class missing the value.

For example:

```cue
Enum: "value1" | "value2" @cuetsy(kind="enum")

MyClass: {
  value: Enum.Value1
} @cuetsy(kind="interface")
```

was generating:
```ts
export enum Enum {
  Value1 = "value1",
  Value2 = "value2",
}

export interface MyClass {
  value: Enum;
}
```

and now it generates:
```ts
export interface MyClass {
  value: Enum.Value1;
}
```