### PR TITLE
Fix adding duplicate fields when they are coming from an extended class

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -577,7 +577,7 @@ func (g *generator) genInterface(name string, v cue.Value) []ts.Decl {
 // Recursively walk down Values returned from Expr() and separate
 // unified/embedded structs from a struct literal, so that we can make the
 // former (if they are also marked with @cuetsy(kind="interface")) show up
-// as "extends" instead of writing out their fields directly.
+// as "extends" instead of inlining their fields.
 func findExtends(v cue.Value) ([]ts.Expr, cue.Value, error) {
 	var extends []ts.Expr
 	// Create an empty value, onto which we'll unify fields that need not be

--- a/testdata/imports/extend_without_duplicates.txtar
+++ b/testdata/imports/extend_without_duplicates.txtar
@@ -1,0 +1,43 @@
+-- cue.mod/module.cue --
+module: "example.com"
+
+-- one.cue --
+package test
+
+import "example.com/dep"
+
+#Extended: {
+  dep.#Base
+  #AStruct
+  #BStruct
+  field: string
+} @cuetsy(kind="interface")
+
+#AStruct: {
+    anotherField: string
+} @cuetsy(kind="interface")
+
+#BStruct: {
+    moreField: string
+} @cuetsy(kind="interface")
+
+-- dep/file.cue --
+package dep
+
+#Base: {
+    baseField: string
+} @cuetsy(kind="interface")
+
+-- out/gen --
+
+export interface Extended extends dep.Base, AStruct, BStruct {
+  field: string;
+}
+
+export interface AStruct {
+  anotherField: string;
+}
+
+export interface BStruct {
+  moreField: string;
+}


### PR DESCRIPTION
Fixes: https://github.com/grafana/schematization-and-as-code-project/issues/64

The main issue was the way that we are unifying the values in `nolit`. Executing Unify itself, it adds extra nested levels for every new value. It only "detects" the nested value as an extended interface and its why it only works with the last value defined.

For any reason, use an empty Value to generate the tree does the trick 🤷🏻‍♀️. 

More "visual" example should be:
```cue
A: {
  B
  C
  D
}

B: {
 b: string
}

C: {
  c: string
}

D: {
  d: string
}
````

It was generating:
```
:
(struct)

:
[&]  (struct)
├── (struct)
└── (struct)

:
[&]  _|_
├── [&]  (struct)
│   ├── (struct)
│   └── (struct)
└── (struct)

:
[&]  _|_
├── [&]  (struct)
│   ├── [&]  (struct)
│   │   ├── (struct)
│   │   └── (struct)
│   └── (struct)
└── (struct)
````

Now:
```
:
(struct)

:
[&]  (struct)
├── (struct)
└── [&]  (struct)
    ├── (struct)
    └── (struct)

:
[&]  (struct)
├── (struct)
└── [&]  (struct)
    ├── [&]  (struct)
    │   ├── (struct)
    │   └── [&]  (struct)
    │       ├── (struct)
    │       └── (struct)
    └── (struct)

:
[&]  (struct)
├── (struct)
└── [&]  (struct)
    ├── [&]  (struct)
    │   ├── (struct)
    │   └── [&]  (struct)
    │       ├── [&]  (struct)
    │       │   ├── (struct)
    │       │   └── [&]  (struct)
    │       │       ├── (struct)
    │       │       └── (struct)
    │       └── (struct)
    └── (struct)
```

So `BottomKind` disappears.