### PR TITLE
Allow override values in child

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -80,6 +80,7 @@ func targetsKind(v cue.Value, kinds ...TSType) bool {
 	if len(kinds) == 0 {
 		kinds = allKinds[:]
 	}
+
 	for _, knd := range kinds {
 		if vkind == knd {
 			return true
@@ -116,6 +117,23 @@ func containsCuetsyReference(v cue.Value, kinds ...TSType) bool {
 			return true
 		}
 	}
+
+	return hasOverrideValues(v, kinds...)
+}
+
+func hasOverrideValues(v cue.Value, kinds ...TSType) bool {
+	// When a value overrides the parent, its marked as BottomKind with two elements
+	op, values := v.Expr()
+	if op != cue.AndOp && len(values) != 2 {
+		return false
+	}
+
+	for _, dv := range flatten(values[1]) {
+		if isReference(dv) && targetsKind(cue.Dereference(dv), kinds...) {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/analyze.go
+++ b/analyze.go
@@ -80,7 +80,6 @@ func targetsKind(v cue.Value, kinds ...TSType) bool {
 	if len(kinds) == 0 {
 		kinds = allKinds[:]
 	}
-
 	for _, knd := range kinds {
 		if vkind == knd {
 			return true

--- a/generator.go
+++ b/generator.go
@@ -899,7 +899,7 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 		if ref != nil {
 			return ref, nil
 		}
-		return nil, valError(v, "failed to generate reference correctly")
+		return nil, valError(v, "failed to generate reference correctly for path %s", v.Path().String())
 	}
 
 	verr := v.Validate(cue.Final())
@@ -1270,7 +1270,7 @@ func referenceValueAs(v cue.Value, kinds ...TSType) (ts.Expr, error) {
 			}, nil
 		}
 	default:
-		return nil, valError(v, "unknown selector subject type %T, cannot translate", dvals[0].Source())
+		return nil, valError(v, "unknown selector subject type %T, cannot translate path %s", dvals[0].Source(), v.Path().String())
 	}
 
 	return nil, nil

--- a/generator.go
+++ b/generator.go
@@ -1218,13 +1218,16 @@ func referenceValueAs(v cue.Value, kinds ...TSType) (ts.Expr, error) {
 
 	if !isReference(v) {
 		_, has := v.Default()
-		if !has || !isReference(dvals[0]) {
+		if hasOverrideValues(v) {
+			v = dvals[1]
+		} else if !has || !isReference(dvals[0]) {
 			return nil, valError(v, "references within complex logic are currently unsupported")
+		} else {
+			v = dvals[0]
 		}
 
 		// This may break a bunch of things but let's see if it gives us a
 		// defensible baseline
-		v = dvals[0]
 		op, dvals = v.Expr()
 	}
 

--- a/testdata/multi_level_type_extension.txtar
+++ b/testdata/multi_level_type_extension.txtar
@@ -1,0 +1,27 @@
+-- cue --
+
+#AType: "a" | "b" | "c"          @cuetsy(kind="type")
+#BType: "d" | "e" | "f" | #AType @cuetsy(kind="type")
+
+#Base: {
+	type:  #BType
+} @cuetsy(kind="interface")
+
+#Struct: {
+    #Base
+	type:  #AType
+} @cuetsy(kind="interface")
+
+-- ts --
+
+export type AType = ('a' | 'b' | 'c');
+
+export type BType = ('d' | 'e' | 'f' | AType);
+
+export interface Base {
+  type: BType;
+}
+
+export interface Struct extends Base {
+  type: AType;
+}

--- a/testdata/multi_level_type_extension.txtar
+++ b/testdata/multi_level_type_extension.txtar
@@ -3,13 +3,26 @@
 #AType: "a" | "b" | "c"          @cuetsy(kind="type")
 #BType: "d" | "e" | "f" | #AType @cuetsy(kind="type")
 
+
+
 #Base: {
-	type:  #BType
+	type:        #BType
+	anotherType: #BType
+} @cuetsy(kind="interface")
+
+#InterfaceOne: {
+    name?: string
+} @cuetsy(kind="interface")
+
+#InterfaceTwo: {
+    prop?: string
 } @cuetsy(kind="interface")
 
 #Struct: {
     #Base
-	type:  #AType
+	type:        #AType
+	expr:        #InterfaceOne | #InterfaceTwo
+	anotherType: #BType & "e"
 } @cuetsy(kind="interface")
 
 -- ts --
@@ -19,9 +32,20 @@ export type AType = ('a' | 'b' | 'c');
 export type BType = ('d' | 'e' | 'f' | AType);
 
 export interface Base {
+  anotherType: BType;
   type: BType;
 }
 
+export interface InterfaceOne {
+  name?: string;
+}
+
+export interface InterfaceTwo {
+  prop?: string;
+}
+
 export interface Struct extends Base {
+  anotherType: 'e';
+  expr: (InterfaceOne | InterfaceTwo);
   type: AType;
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/schematization-and-as-code-project/issues/59

When a child overrides parent value, instead of put the new value, we were putting the type instead.

This is happening because we have a disjunction in this case and we aren't able to find the reference of this type. For that, we need to iterate a level more to see if its overwriting this value.

The overriding struct is a BottomKind with two elements inside, but it has the same structure than the fields with default values (`#AType & "a"`). The difference between them is the `cue.OrOp` operator that we can skip.

**Note**: When you set an invalid override value, it doesn't write anything in TS file.

Also I added the path in the logs because its easier to identify what was wrong.