### PR TITLE
Fix enums defaults generation when we extending from a parent class

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -754,6 +754,7 @@ func (g *generator) genEnumReference(v cue.Value) (*typeRef, error) {
 			return nil, ve
 		}
 	case 3:
+		// It could happen when we are setting a default value into a parent field.
 		if !conjuncts[0].Equals(conjuncts[1]) {
 			ve := valError(v, "complex unifications containing references to enums without overriding parent are not currently supported")
 			g.addErr(ve)

--- a/generator.go
+++ b/generator.go
@@ -515,7 +515,7 @@ func (g *generator) genInterface(name string, v cue.Value) []ts.Decl {
 			op, _ := iter.Value().Expr()
 			// Also we need to check if the sub operator to discard the one that have validators and if it has a default
 			subOp, _ := sub.Expr()
-			_, def := sub.Default()
+			_, def := iter.Value().Default()
 			if sub.Exists() && sub.Equals(iter.Value()) && (subOp == cue.AndOp || op != cue.AndOp || !def) {
 				continue
 			}

--- a/generator.go
+++ b/generator.go
@@ -1285,7 +1285,6 @@ func referenceValueAs(v cue.Value, kinds ...TSType) (ts.Expr, error) {
 		// (We can't do cycle detection with the meager tools
 		// exported in cuelang.org/go/cue, so all we have for the
 		// parent case is hopium.)
-
 		if _, ok := dvals[1].Source().(*ast.Ident); ok && targetsKind(deref, kinds...) {
 			return ts.Ident(dstr), nil
 		}

--- a/testdata/imports/defaults_from_extension.txtar
+++ b/testdata/imports/defaults_from_extension.txtar
@@ -1,0 +1,36 @@
+-- cue.mod/module.cue --
+module: "example.com"
+
+-- one.cue --
+package test
+
+import "example.com/dep"
+
+#Struct: {
+    dep.#Base
+    baseEnum: dep.#BaseEnum & (*"enumA" | _|_)
+    show: bool | *true
+} @cuetsy(kind="interface")
+
+-- dep/file.cue --
+package dep
+
+#BaseType: "typeA" | "typeB" @cuetsy(kind="type")
+#BaseEnum: "enumA" | "enumB" @cuetsy(kind="enum")
+
+#Base: {
+  baseEnum: #BaseEnum
+  show:     bool
+} @cuetsy(kind="interface")
+
+-- out/gen --
+
+export interface Struct extends dep.Base {
+  baseEnum: BaseEnum;
+  show: boolean;
+}
+
+export const defaultStruct: Partial<Struct> = {
+  baseEnum: BaseEnum.EnumA,
+  show: true,
+};

--- a/testdata/imports/defaults_from_extension.txtar
+++ b/testdata/imports/defaults_from_extension.txtar
@@ -20,6 +20,8 @@ package dep
 
 #Base: {
   baseEnum: #BaseEnum
+  defaultBaseEnum: #BaseEnum | *"enumB"
+  valueWithValidator?: int32 & >=0
   show:     bool
 } @cuetsy(kind="interface")
 


### PR DESCRIPTION
Fixes enums case for: https://github.com/grafana/schematization-and-as-code-project/issues/56

We can set a default enum value to a field from a parent class using:
```cue
common.LegendDisplayMode & (*"list" | _|_)
```

The issue was using `TopKind` (`_`) but I couldn't make it work with that :(