### PR TITLE
Allow set enum defaults when override a parent value

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -225,7 +225,6 @@ func findRefWithKind(v cue.Value, kinds ...TSType) (ref, referrer cue.Value, has
 // appendSplit splits a cue.Value into the
 func appendSplit(a []cue.Value, splitBy cue.Op, v cue.Value) []cue.Value {
 	op, args := v.Expr()
-
 	// dedup elements.
 	k := 1
 outer:

--- a/analyze.go
+++ b/analyze.go
@@ -225,6 +225,7 @@ func findRefWithKind(v cue.Value, kinds ...TSType) (ref, referrer cue.Value, has
 // appendSplit splits a cue.Value into the
 func appendSplit(a []cue.Value, splitBy cue.Op, v cue.Value) []cue.Value {
 	op, args := v.Expr()
+
 	// dedup elements.
 	k := 1
 outer:
@@ -248,6 +249,12 @@ outer:
 	} else {
 		for _, v := range args {
 			a = appendSplit(a, splitBy, v)
+		}
+	}
+
+	if defaultValue, is := v.Default(); is {
+		if o, _ := v.Expr(); o == cue.NoOp {
+			a = append(a, defaultValue)
 		}
 	}
 	return a

--- a/testdata/fields_with_default_enums.txtar
+++ b/testdata/fields_with_default_enums.txtar
@@ -1,0 +1,43 @@
+-- cue --
+
+#Enum: "a" | "b" | "c" @cuetsy(kind="enum")
+
+#Base: {
+    valueEnum:   #Enum
+    defaultEnum: #Enum
+} @cuetsy(kind="interface")
+
+#StructWithDefaults: {
+    #Base
+    baseEnum:              #Enum
+    valueEnum:             #Enum & "a"
+    defaultEnum:           #Enum | *"a"
+    noOverrideDefaultEnum: #Enum | *"b"
+    noOverrideEnum:        #Enum & "b"
+} @cuetsy(kind="interface")
+
+-- ts --
+
+export enum Enum {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+
+export interface Base {
+  defaultEnum: Enum;
+  valueEnum: Enum;
+}
+
+export interface StructWithDefaults extends Base {
+  baseEnum: Enum;
+  defaultEnum: Enum;
+  noOverrideDefaultEnum: Enum;
+  noOverrideEnum: Enum.B;
+  valueEnum: Enum.A;
+}
+
+export const defaultStructWithDefaults: Partial<StructWithDefaults> = {
+  defaultEnum: Enum.A,
+  noOverrideDefaultEnum: Enum.B,
+};


### PR DESCRIPTION
Fixes enums case from this issue: https://github.com/grafana/schematization-and-as-code-project/issues/56

It fixes the issue that doesn't generate the default values when we are setting them using a parent field.

The difference from this PR: https://github.com/grafana/cuetsy/pull/86 is that this PR allows to set default values like:

```cue
parentField: #Enum & *"defaultValue"
```

and we don't need to use the ugly way `(*"defaultValue" | _)` for defaults.