### PR TITLE
Allow set enum defaults when override a parent value

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -130,7 +130,7 @@ func hasOverrideValues(v cue.Value, kinds ...TSType) bool {
 	}
 
 	defaultOp, _ := values[1].Expr()
-	if defaultOp == cue.AndOp {
+	if defaultOp == cue.AndOp || defaultOp == cue.OrOp {
 		return false
 	}
 

--- a/analyze.go
+++ b/analyze.go
@@ -129,8 +129,7 @@ func hasOverrideValues(v cue.Value, kinds ...TSType) bool {
 		return false
 	}
 
-	defaultOp, _ := values[1].Expr()
-	if defaultOp == cue.AndOp || defaultOp == cue.OrOp {
+	if values[1].Kind() != cue.BottomKind || values[1].IncompleteKind() == cue.TopKind {
 		return false
 	}
 

--- a/testdata/fields_with_default_types.txtar
+++ b/testdata/fields_with_default_types.txtar
@@ -1,0 +1,44 @@
+-- cue --
+
+#Type: "a" | "b" | "c" @cuetsy(kind="type")
+
+#Base: {
+    valueType:   #Type
+    defaultType: #Type
+} @cuetsy(kind="interface")
+
+#StructWithDefaults: {
+    #Base
+    baseType:              #Type
+    valueType:             #Type
+    defaultType:           #Type | (*"a" | _)
+    noOverrideDefaultType: #Type | (*"b" | _)
+    noOverrideType:        #Type
+    defaultString:         #Type | *"invalid"
+    defaultNumber:         #Type | "something" | *34
+} @cuetsy(kind="interface")
+
+-- ts --
+
+export type Type = ('a' | 'b' | 'c');
+
+export interface Base {
+  defaultType: Type;
+  valueType: Type;
+}
+
+export interface StructWithDefaults extends Base {
+  baseType: Type;
+  defaultNumber: Type;
+  defaultString: Type;
+  defaultType: Type;
+  noOverrideDefaultType: Type;
+  noOverrideType: Type;
+}
+
+export const defaultStructWithDefaults: Partial<StructWithDefaults> = {
+  defaultNumber: 34,
+  defaultString: 'invalid',
+  defaultType: 'a',
+  noOverrideDefaultType: 'b',
+};

--- a/testdata/fields_with_default_types.txtar
+++ b/testdata/fields_with_default_types.txtar
@@ -11,8 +11,8 @@
     #Base
     baseType:              #Type
     valueType:             #Type
-    defaultType:           #Type | (*"a" | _)
-    noOverrideDefaultType: #Type | (*"b" | _)
+    defaultType:           #Type & (*"a" | _)
+    noOverrideDefaultType: #Type & (*"b" | _)
     noOverrideType:        #Type
     defaultString:         #Type | *"invalid"
     defaultNumber:         #Type | "something" | *34


### PR DESCRIPTION
Fixes type case from this issue: https://github.com/grafana/schematization-and-as-code-project/issues/56

It changes the way to set defaults like enums using `#Type & (*"value" | _)`.