### PR TITLE
Fix E3 test enum

### DIFF
--- a/cmd/cuetsy/test.cue
+++ b/cmd/cuetsy/test.cue
@@ -2,10 +2,7 @@ package cuetsy
 
 E1: "e1str1" | "e1str2" | "e1str3" @cuetsy(kind="enum")
 E2: "e2str1" | "e2str2" | "e2str3" | "e2str4" @cuetsy(kind="enum")
-E3: {
-  Walla: "laadeedaa"
-  run: "OMG"
-} @cuetsy(kind="enum")
+E3: "laadeedaa" | "run" @cuetsy(kind="enum", memberNames="Walla|OMG")
 
 I1: {
   I1_OptionalDisjunctionLiteral?: "other" | "values" | 2


### PR DESCRIPTION
Fixes: https://github.com/grafana/cuetsy/issues/81

We are using `memberNames` to put custom names to the enum values.