### PR TITLE
Allow recursive values

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -1032,6 +1032,10 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 			v = dvals[0]
 		}
 
+		if op == cue.OrOp {
+			return disj(dvals)
+		}
+
 		e := v.LookupPath(cue.MakePath(cue.AnyIndex))
 		if e.Exists() {
 			expr, err := tsprintField(e, isType)
@@ -1072,6 +1076,9 @@ func tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 		// with disjunctions and basic types.
 		switch op {
 		case cue.OrOp:
+			if len(dvals) == 2 && dvals[0].Kind() == cue.NullKind {
+				return tsprintField(dvals[1], isType)
+			}
 			return disj(dvals)
 		case cue.NoOp, cue.AndOp:
 			// There's no op for simple unification; it's a basic type, and can

--- a/testdata/recursive.txtar
+++ b/testdata/recursive.txtar
@@ -8,6 +8,11 @@ Recursive: {
     map: [string]: Recursive
     multipleValues: 23 | "abc" | [...MyStruct] | [...Recursive]
     union: [...MyStruct] | [...Recursive]
+    optionalValue?: Recursive
+    optionalList?: [...Recursive]
+    optionalMap?: [string]: Recursive
+    optionalMultipleValues?: 23 | "abc" | [...MyStruct] | [...Recursive]
+    optionalUnion?: [...MyStruct] | [...Recursive]
 } @cuetsy(kind="interface")
 
 -- ts --
@@ -19,10 +24,16 @@ export interface Recursive {
   map: Record<string, Recursive>;
   multipleValues: (23 | 'abc' | Array<MyStruct> | Array<Recursive>);
   myValue: string;
+  optionalList?: Array<Recursive>;
+  optionalMap?: Record<string, Recursive>;
+  optionalMultipleValues?: (23 | 'abc' | Array<MyStruct> | Array<Recursive>);
+  optionalUnion?: (Array<MyStruct> | Array<Recursive>);
+  optionalValue?: Recursive;
   union: (Array<MyStruct> | Array<Recursive>);
   value: Recursive;
 }
 
 export const defaultRecursive: Partial<Recursive> = {
   list: [],
+  optionalList: [],
 };

--- a/testdata/recursive.txtar
+++ b/testdata/recursive.txtar
@@ -1,0 +1,28 @@
+-- cue --
+MyStruct: {} @cuetsy(kind="interface")
+
+Recursive: {
+    myValue: string
+    value: null | Recursive
+    list: [...Recursive]
+    map: [string]: Recursive
+    multipleValues: 23 | "abc" | [...MyStruct] | [...Recursive]
+    union: [...MyStruct] | [...Recursive]
+} @cuetsy(kind="interface")
+
+-- ts --
+
+export interface MyStruct {}
+
+export interface Recursive {
+  list: Array<Recursive>;
+  map: Record<string, Recursive>;
+  multipleValues: (23 | 'abc' | Array<MyStruct> | Array<Recursive>);
+  myValue: string;
+  union: (Array<MyStruct> | Array<Recursive>);
+  value: Recursive;
+}
+
+export const defaultRecursive: Partial<Recursive> = {
+  list: [],
+};


### PR DESCRIPTION
Fixes: https://github.com/grafana/schematization-and-as-code-project/issues/52

The important thing here is that `cue` needs a stop condition. Lists, optionals and maps could be null so the way to set these values are predecible.

But to set a simple value we need to set `null | Recursive` to make it works. Its to indicate to cue that it could have a finish condition because the last value could be a null. More info: https://cuelang.org/docs/references/spec/#structural-cycles