### PR TITLE
Fix unions that includes enums and a default value

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -201,7 +201,7 @@ func (g *generator) genType(name string, v cue.Value) []ts.Decl {
 	switch op {
 	case cue.OrOp:
 		for _, dv := range dvals {
-			tok, err := g.tsprintField(dv, true)
+			tok, err := g.tsprintField(dv, true, false)
 			if err != nil {
 				g.addErr(err)
 				return nil
@@ -209,7 +209,7 @@ func (g *generator) genType(name string, v cue.Value) []ts.Decl {
 			tokens = append(tokens, tok)
 		}
 	case cue.NoOp, cue.RegexMatchOp:
-		tok, err := g.tsprintField(v, true)
+		tok, err := g.tsprintField(v, true, false)
 		if err != nil {
 			g.addErr(err)
 			return nil
@@ -233,7 +233,7 @@ func (g *generator) genType(name string, v cue.Value) []ts.Decl {
 		return ret[:1]
 	}
 
-	val, err := g.tsprintField(d, false)
+	val, err := g.tsprintField(d, false, false)
 	g.addErr(err)
 
 	def := tsast.VarDecl{
@@ -643,7 +643,7 @@ func (g *generator) genInterfaceField(v cue.Value) (*typeRef, error) {
 
 	tref := &typeRef{}
 	var err error
-	tref.T, err = g.tsprintField(v, true)
+	tref.T, err = g.tsprintField(v, true, false)
 	if err != nil {
 		if !containsCuetsyReference(v) {
 			g.addErr(valError(v, "could not generate field: %w", err))
@@ -984,7 +984,8 @@ func (g generator) tsPrintDefault(v cue.Value) (bool, ts.Expr, error) {
 	// }
 
 	if ok {
-		expr, err := g.tsprintField(d, false)
+		tpv(d)
+		expr, err := g.tsprintField(d, false, true)
 		if err != nil {
 			return false, nil, err
 		}
@@ -1008,16 +1009,30 @@ func (g generator) tsPrintDefault(v cue.Value) (bool, ts.Expr, error) {
 	return false, nil, nil
 }
 
+func shouldIterateValue(v cue.Value, isDefault bool) (cue.Value, bool) {
+	op, _ := v.Expr()
+	if isDefault {
+		def, has := v.Default()
+		if has {
+			v = def
+		} else if v.Kind() != cue.StructKind && op != cue.NoOp {
+			return cue.Value{}, false
+		}
+	}
+
+	return v, true
+}
+
 // Render a string containing a Typescript semantic equivalent to the provided
 // Value for placement in a single field, if possible.
-func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
+func (g generator) tsprintField(v cue.Value, isType bool, isDefault bool) (ts.Expr, error) {
 	if hasEnumReference(v) {
 		ref, err := g.genEnumReference(v)
 		return ref.T, err
 	}
 
 	// References are orthogonal to the Kind system. Handle them first.
-	if hasTypeReference(v) || containsCuetsyReference(v, TypeInterface) || hasEnumReference(v) {
+	if hasTypeReference(v) || containsCuetsyReference(v, TypeInterface) {
 		ref, err := referenceValueAs(v)
 		if err != nil {
 			return nil, err
@@ -1047,7 +1062,7 @@ func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 			// It skips structs like {...} (cue.TopKind) to avoid undesired results.
 			val := v.LookupPath(cue.MakePath(cue.AnyString))
 			if val.Exists() && val.IncompleteKind() != cue.TopKind {
-				expr, err := g.tsprintField(val, isType)
+				expr, err := g.tsprintField(val, isType, isDefault)
 				if err != nil {
 					return nil, valError(v, err.Error())
 				}
@@ -1068,7 +1083,11 @@ func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 			size, _ := v.Len().Int64()
 			kvs := make([]tsast.KeyValueExpr, 0, size)
 			for iter.Next() {
-				expr, err := g.tsprintField(iter.Value(), isType)
+				value, ok := shouldIterateValue(iter.Value(), isDefault)
+				if !ok {
+					continue
+				}
+				expr, err := g.tsprintField(value, isType, isDefault)
 				if err != nil {
 					return nil, valError(v, err.Error())
 				}
@@ -1098,7 +1117,7 @@ func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 		iter, _ := v.List()
 		var elems []ts.Expr
 		for iter.Next() {
-			e, err := g.tsprintField(iter.Value(), isType)
+			e, err := g.tsprintField(iter.Value(), isType, isDefault)
 			if err != nil {
 				return nil, err
 			}
@@ -1114,7 +1133,7 @@ func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 	disj := func(dvals []cue.Value) (ts.Expr, error) {
 		parts := make([]ts.Expr, 0, len(dvals))
 		for _, dv := range dvals {
-			p, err := g.tsprintField(dv, isType)
+			p, err := g.tsprintField(dv, isType, isDefault)
 			if err != nil {
 				return nil, err
 			}
@@ -1163,7 +1182,7 @@ func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 
 		e := v.LookupPath(cue.MakePath(cue.AnyIndex))
 		if e.Exists() {
-			expr, err := g.tsprintField(e, isType)
+			expr, err := g.tsprintField(e, isType, isDefault)
 			if err != nil {
 				return nil, err
 			}
@@ -1208,7 +1227,7 @@ func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 		switch op {
 		case cue.OrOp:
 			if len(dvals) == 2 && dvals[0].Kind() == cue.NullKind {
-				return g.tsprintField(dvals[1], isType)
+				return g.tsprintField(dvals[1], isType, isDefault)
 			}
 			return disj(dvals)
 		case cue.AndOp:

--- a/testdata/join_schemas.txtar
+++ b/testdata/join_schemas.txtar
@@ -1,0 +1,97 @@
+-- cue --
+
+#Enum: "foo" | "bar" @cuetsy(kind="enum")
+
+#Lineage: {
+    joinSchema: _
+    #Sequence: {
+        schemas: [joinSchema, ...joinSchema]
+    }
+    seqs: [...#Sequence]
+}
+
+#MyLineage: #Lineage & {
+    seqs: [{
+        schemas: [
+            {
+                union:  #Enum | "foo" | 33
+                union1: #Enum | *"a"
+                union2: #Enum | *"foo"
+                union3: #Enum | "bar"
+                union4: *#Enum | "foo"
+                union5: [...#Enum] | *{[string]: [...#Enum]}
+                union6: "a" | *{
+                             value: "b"
+                             value1: string
+                          }
+                union7: {
+                    nested: {
+                        union: *#Enum | "foo"
+                        union1: "a" | *{
+                                     value: "b"
+                                     value1: string
+                                  }
+                    }
+                }
+            }
+        ]
+    }]
+} @cuetsy(kind="interface")
+
+-- ts --
+
+export enum Enum {
+  Bar = 'bar',
+  Foo = 'foo',
+}
+
+export interface MyLineage {
+  joinSchema: unknown;
+  seqs: [{
+    schemas: [{
+      union: (Enum | 'foo' | 33);
+      union1: (Enum | 'a');
+      union2: (Enum | 'foo');
+      union3: (Enum | 'bar');
+      union4: (Enum | 'foo');
+      union5: (Array<Enum> | Record<string, Array<Enum>>);
+      union6: ('a' | {
+          value: 'b';
+          value1: string;
+        });
+      union7: {
+        nested: {
+          union: (Enum | 'foo');
+          union1: ('a' | {
+              value: 'b';
+              value1: string;
+            });
+        };
+      };
+    }];
+  }];
+}
+
+export const defaultMyLineage: Partial<MyLineage> = {
+  seqs: [{
+    schemas: [{
+      union1: 'a',
+      union2: 'foo',
+      union4: Enum,
+      union5: Record<string, Array<Enum>>,
+      union6: {
+        value: 'b',
+        value1: string,
+      },
+      union7: {
+        nested: {
+          union: Enum,
+          union1: {
+            value: 'b',
+            value1: string,
+          },
+        },
+      },
+    }],
+  }],
+};


### PR DESCRIPTION
We fixed the enums defaults in this PR: https://github.com/grafana/cuetsy/pull/87. All tests passed correctly but when we execute this code against Grafana cue files, the results isn't the expected one.

~I didn't add tests because I don't know how to write the cue structure to reproduce the case from there 😞.~
_Edit_: We could find the way to reproduce the use case 😄. Also, because the test needs nested struct defaults to pass, I need to update the code to allow these defaults.

It happens when we set an Enum and a default value:
```cue
value: #Enum | *"a"
```

We expecting to have the following code:
```ts
export interface Blah {
  value: (Enum | 'a');
}

export const defaultValue = Partial<Blah> = {
  value: 'a',
}
```

But its generating:
```ts
export interface Blah {
  value: string;
}

export const defaultValue = Partial<Blah> = {
  value: 'a',
}
```

**Why was the reason?** Because the struct that Cuetsy received is slightly different.
In our tests:
```cue
[|]  (string)
├── [.]  (string)
│   ├── (struct)
│   ├── "#Enum"
│   └── [ref:#Enum]  
│       └── [|]  (string) @cuetsy(kind="enum")
│           ├── "a"
│           ├── "b"
│           └── "c"
├── "a"
└── [*]  
    └── "a"
```
Grafana cue:
```cue
[]  (string)
├── [.]  (string)
│   ├── (struct)
│   ├── "#Enum"
│   └── [ref:#Enum]
│       └── [|]  (string) @cuetsy(kind="enum")
│           ├── "a"
│           ├── "b"
│           └── "c"
└── [*]
    └── "a"
```

We can see that the second one doesn't have the "a" value and we weren't analyse the `cue.NoOp` case for this. 

So the solution is detecting the `Selector` operator from the first value (the Enum) to avoid to confusing it with values with validators that reaches this point (Ex: `uint32 & >0 | *9`), and add the default value like an existing one.