### PR TITLE
Fix null types generation

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -48,7 +48,6 @@ func TestGenerateWithImports(t *testing.T) {
 			"imports/struct_shorthand": "Shorthand struct notation is currently unsupported, needs fixing",
 			"imports/single_embed":     "Single-item struct embeds should be treated as just another interface to compose, but get confused with references - #60",
 			"imports/inline_comments":  "Inline comments do not appear be retrievable from cue.Value.Doc()",
-			"imports/nulltype":         "null types are not handled correctly",
 		},
 	}
 

--- a/generator.go
+++ b/generator.go
@@ -1226,7 +1226,13 @@ func (g generator) tsprintField(v cue.Value, isType bool) (ts.Expr, error) {
 			return nil, valError(v, "bounds constraints are not supported as they lack a direct typescript equivalent")
 		}
 		fallthrough
-	case cue.FloatKind, cue.IntKind, cue.BoolKind, cue.NullKind, cue.StructKind:
+	case cue.NullKind:
+		// It evaluates single null value
+		if op == cue.NoOp && len(dvals) == 0 {
+			return tsprintType(cue.NullKind), nil
+		}
+		fallthrough
+	case cue.FloatKind, cue.IntKind, cue.BoolKind, cue.StructKind:
 		// Having eliminated the possibility of bounds/constraints, we're left
 		// with disjunctions and basic types.
 		switch op {
@@ -1292,6 +1298,8 @@ func tsprintType(k cue.Kind) ts.Expr {
 		return ts.Ident("number")
 	case cue.TopKind:
 		return ts.Ident("unknown")
+	case cue.NullKind:
+		return ts.Ident("null")
 	default:
 		return nil
 	}

--- a/testdata/imports/nulltype.txtar
+++ b/testdata/imports/nulltype.txtar
@@ -15,12 +15,12 @@ obj: {
 
 export type nullType = null;
 
-export type nullInUnion = string | null;
+export type nullInUnion = (string | null);
 
-export type nullDefault = "foo" | "bar" | null;
+export type nullDefault = ('foo' | 'bar' | null);
 
 export const defaultnullDefault: nullDefault = null;
 
 export interface obj {
-    nullField: null
+  nullField: null;
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/cuetsy/issues/79

It fixes null types in schemas. 

I detected that a several things could reach `cue.NullKind`, so doing an inspection of the schemas, the easiest way to evaluate the nulls is the single case. The rest of cases can be evaluated in the next case and its why the `fallthrough`.