### PR TITLE
Fix structs with only one reference

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -46,7 +46,6 @@ func TestGenerateWithImports(t *testing.T) {
 		ToDo: map[string]string{
 			"imports/oneref_verbose":   "Figure out how to disambiguate struct literals from the struct-with-braces-and-one-element case",
 			"imports/struct_shorthand": "Shorthand struct notation is currently unsupported, needs fixing",
-			"imports/single_embed":     "Single-item struct embeds should be treated as just another interface to compose, but get confused with references - #60",
 			"imports/inline_comments":  "Inline comments do not appear be retrievable from cue.Value.Doc()",
 			"imports/nulltype":         "null types are not handled correctly",
 		},

--- a/generator.go
+++ b/generator.go
@@ -1308,7 +1308,7 @@ func valError(v cue.Value, format string, args ...interface{}) error {
 func refAsInterface(v cue.Value) (ts.Expr, error) {
 	// Bail out right away if the value isn't a reference
 	op, dvals := v.Expr()
-	if !isReference(v) || op != cue.SelectorOp {
+	if !isReference(v) && op != cue.SelectorOp {
 		return nil, fmt.Errorf("not a reference")
 	}
 

--- a/testdata/imports/single_embed.txtar
+++ b/testdata/imports/single_embed.txtar
@@ -37,8 +37,9 @@ export interface Attrib {
   ImportedInner: {
     nestedval: string;
   };
-  importedNoAttribField: string;
+  importedAttribField: string;
 }
 
 export interface Wrapped extends Attrib {}
-export interface dep.Wrapped extends dep.Attrib {}
+
+export interface DepWrapped extends dep.Attrib {}


### PR DESCRIPTION
Fixes: https://github.com/grafana/cuetsy/issues/60

We have a small bug that make structs with one ref, mainly because `!isReference(v)` was always true.