### PR TITLE
Fix inline comments

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -47,7 +47,6 @@ func TestGenerateWithImports(t *testing.T) {
 			"imports/oneref_verbose":   "Figure out how to disambiguate struct literals from the struct-with-braces-and-one-element case",
 			"imports/struct_shorthand": "Shorthand struct notation is currently unsupported, needs fixing",
 			"imports/single_embed":     "Single-item struct embeds should be treated as just another interface to compose, but get confused with references - #60",
-			"imports/inline_comments":  "Inline comments do not appear be retrievable from cue.Value.Doc()",
 			"imports/nulltype":         "null types are not handled correctly",
 		},
 	}

--- a/generator.go
+++ b/generator.go
@@ -1431,17 +1431,6 @@ func referenceValueAs(v cue.Value, kinds ...TSType) (ts.Expr, error) {
 	return nil, nil
 }
 
-func commentsForGroup(cgs []*ast.CommentGroup, jsdoc bool) []tsast.Comment {
-	if cgs == nil {
-		return nil
-	}
-	ret := make([]tsast.Comment, 0, len(cgs))
-	for _, cg := range cgs {
-		ret = append(ret, ts.CommentFromCUEGroup(cg, jsdoc))
-	}
-	return ret
-}
-
 func commentsFor(v cue.Value, jsdoc bool) []tsast.Comment {
 	docs := v.Doc()
 	if s, ok := v.Source().(*ast.Field); ok {
@@ -1452,5 +1441,13 @@ func commentsFor(v cue.Value, jsdoc bool) []tsast.Comment {
 		}
 	}
 
-	return commentsForGroup(docs, jsdoc)
+	ret := make([]tsast.Comment, 0, len(docs))
+	for _, cg := range docs {
+		ret = append(ret, ts.CommentFromCUEGroup(ts.Comment{
+			Text:      cg.Text(),
+			Multiline: cg.Doc && !cg.Line,
+			JSDoc:     jsdoc,
+		}))
+	}
+	return ret
 }

--- a/generator.go
+++ b/generator.go
@@ -277,7 +277,6 @@ type KV struct {
 //     if memberNames is absent, then keys implicitly generated as CamelCase
 //   - string struct: struct keys get enum keys, struct values enum values
 func (g *generator) genEnum(name string, v cue.Value) []ts.Decl {
-	vdoc := v.Doc()
 	// FIXME compensate for attribute-applying call to Unify() on incoming Value
 	op, dvals := v.Expr()
 	if op == cue.AndOp {
@@ -302,7 +301,7 @@ func (g *generator) genEnum(name string, v cue.Value) []ts.Decl {
 	ret[0] = tsast.TypeDecl{
 		Name:        ts.Ident(name),
 		Type:        tsast.EnumType{Elems: exprs},
-		CommentList: commentsForGroup(vdoc, true),
+		CommentList: commentsFor(v, true),
 		Export:      g.c.Export,
 	}
 
@@ -469,7 +468,6 @@ func (g *generator) genInterface(name string, v cue.Value) []ts.Decl {
 	}
 	var elems []tsast.KeyValueExpr
 	var defs []tsast.KeyValueExpr
-
 	iter, _ := v.Fields(cue.Optional(true))
 	for iter != nil && iter.Next() {
 		if iter.Selector().PkgPath() != "" {
@@ -1444,14 +1442,20 @@ func commentsForGroup(cgs []*ast.CommentGroup, jsdoc bool) []tsast.Comment {
 	}
 	ret := make([]tsast.Comment, 0, len(cgs))
 	for _, cg := range cgs {
-		if cg.Line {
-			panic("hit it")
-		}
 		ret = append(ret, ts.CommentFromCUEGroup(cg, jsdoc))
 	}
 	return ret
 }
 
 func commentsFor(v cue.Value, jsdoc bool) []tsast.Comment {
-	return commentsForGroup(v.Doc(), jsdoc)
+	docs := v.Doc()
+	if s, ok := v.Source().(*ast.Field); ok {
+		for _, c := range s.Comments() {
+			if !c.Doc && c.Line {
+				docs = append(docs, c)
+			}
+		}
+	}
+
+	return commentsForGroup(docs, jsdoc)
 }

--- a/generator.go
+++ b/generator.go
@@ -468,6 +468,7 @@ func (g *generator) genInterface(name string, v cue.Value) []ts.Decl {
 	}
 	var elems []tsast.KeyValueExpr
 	var defs []tsast.KeyValueExpr
+
 	iter, _ := v.Fields(cue.Optional(true))
 	for iter != nil && iter.Next() {
 		if iter.Selector().PkgPath() != "" {

--- a/testdata/imports/inline_comments.txtar
+++ b/testdata/imports/inline_comments.txtar
@@ -35,9 +35,9 @@ export type Nested = {
        * tripleInner has a before comment and
        * it's multiline
        */
-      tripleInner: string,
+      tripleInner: string; // tripleInner has an inline comment
     },
   },
 }; // Nested has an inline comment
 
-export type SimpleOnlyInline = string;  // comment on SimpleOnlyInline
+export type SimpleOnlyInline = string; // comment on SimpleOnlyInline

--- a/ts/ast/lit.go
+++ b/ts/ast/lit.go
@@ -54,9 +54,20 @@ func (o ObjectLit) innerString(aeol EOL, lvl int) string {
 
 	write("{\n")
 	for _, e := range o.Elems {
+		hasInlineComments := false
+		for _, c := range e.Comments() {
+			if c.Pos == CommentInline {
+				hasInlineComments = true
+			}
+		}
 		indent(lvl)
 		write(formatInner(aeol, lvl, e))
-		write(eol)
+		if hasInlineComments {
+			write("\n")
+		} else {
+			write(eol)
+		}
+
 	}
 
 	indent(lvl - 1)
@@ -97,7 +108,11 @@ func formatInner(eol EOL, lvl int, n Node) string {
 	b.WriteString(prinner(eol, lvl, n))
 
 	for ; i < len(comms) && comms[i].Pos == CommentInline; i++ {
-		b.WriteString(" " + comms[i].innerString(eol, lvl) + " ")
+		if _, ok := n.(KeyValueExpr); ok {
+			b.WriteString("; " + comms[i].innerString(eol, lvl))
+		} else {
+			b.WriteString(" " + comms[i].innerString(eol, lvl))
+		}
 	}
 
 	for ; i < len(comms); i++ {

--- a/ts/comments.go
+++ b/ts/comments.go
@@ -1,0 +1,92 @@
+package ts
+
+import (
+	"bufio"
+	"strings"
+
+	"github.com/grafana/cuetsy/ts/ast"
+	"github.com/kr/text"
+)
+
+// CommentFromString takes a string input and formats it as an ast.CommentList.
+//
+// Line breaks are automatically inserted to minimize raggedness, with a loose
+// width limit the provided lim.
+//
+// If the jsdoc param is true, the resulting comment will be formatted with
+// JSDoc ( /** ... */ )-style. Otherwise, ordinary comment leader ( // ... ) will
+// be used.
+//
+// The returned ast.CommentList will have the default CommentAbove position.
+func CommentFromString(s string, lim int, jsdoc bool) ast.Comment {
+	var b strings.Builder
+	prefix := func() { b.WriteString("// ") }
+	if jsdoc {
+		b.WriteString("/**\n")
+		prefix = func() { b.WriteString(" * ") }
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(text.Wrap(s, lim)))
+	var i int
+	for scanner.Scan() {
+		if i != 0 {
+			b.WriteString("\n")
+		}
+		prefix()
+		b.WriteString(scanner.Text())
+		i++
+	}
+	if jsdoc {
+		b.WriteString("\n */\n")
+	}
+
+	return ast.Comment{
+		Text: b.String(),
+	}
+}
+
+type Comment struct {
+	Text      string
+	Multiline bool
+	JSDoc     bool
+}
+
+// CommentFromCUEGroup creates an ast.CommentList from a Comment.
+//
+// Original line breaks are preserved, in keeping with principles of semantic line breaks.
+func CommentFromCUEGroup(cg Comment) ast.Comment {
+	var b strings.Builder
+	pos := ast.CommentAbove
+	if !cg.Multiline {
+		pos = ast.CommentInline
+	}
+
+	prefix := func() { b.WriteString("// ") }
+	if cg.JSDoc && cg.Multiline {
+		b.WriteString("/**\n")
+		prefix = func() { b.WriteString(" * ") }
+	} else {
+		b.WriteString("//")
+		prefix = func() { b.WriteString(" ") }
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(cg.Text))
+	var i int
+	for scanner.Scan() {
+		if i != 0 {
+			b.WriteString("\n")
+		}
+		prefix()
+		b.WriteString(scanner.Text())
+		i++
+	}
+	if cg.JSDoc && cg.Multiline {
+		b.WriteString("\n")
+		b.WriteString(" */")
+	}
+
+	return ast.Comment{
+		Text: b.String(),
+		Pos:  pos,
+	}
+}

--- a/ts/ts.go
+++ b/ts/ts.go
@@ -1,12 +1,7 @@
 package ts
 
 import (
-	"bufio"
-	"strings"
-
-	cast "cuelang.org/go/cue/ast"
 	"github.com/grafana/cuetsy/ts/ast"
-	"github.com/kr/text"
 )
 
 type (
@@ -97,81 +92,4 @@ func Bool(b bool) Expr {
 		return Ident("true")
 	}
 	return Ident("false")
-}
-
-// CommentFromString takes a string input and formats it as an ast.CommentList.
-//
-// Line breaks are automatically inserted to minimize raggedness, with a loose
-// width limit the provided lim.
-//
-// If the jsdoc param is true, the resulting comment will be formatted with
-// JSDoc ( /** ... */ )-style. Otherwise, ordinary comment leader ( // ... ) will
-// be used.
-//
-// The returned ast.CommentList will have the default CommentAbove position.
-func CommentFromString(s string, lim int, jsdoc bool) ast.Comment {
-	var b strings.Builder
-	prefix := func() { b.WriteString("// ") }
-	if jsdoc {
-		b.WriteString("/**\n")
-		prefix = func() { b.WriteString(" * ") }
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(text.Wrap(s, lim)))
-	var i int
-	for scanner.Scan() {
-		if i != 0 {
-			b.WriteString("\n")
-		}
-		prefix()
-		b.WriteString(scanner.Text())
-		i++
-	}
-	if jsdoc {
-		b.WriteString("\n */\n")
-	}
-
-	return ast.Comment{
-		Text: b.String(),
-	}
-}
-
-// CommentFromCUEGroup creates an ast.CommentList from a CUE AST CommentGroup.
-//
-// Original line breaks are preserved, in keeping with principles of semantic line breaks.
-func CommentFromCUEGroup(cg *cast.CommentGroup, jsdoc bool) ast.Comment {
-	var b strings.Builder
-	pos := ast.CommentAbove
-	if cg.Line {
-		pos = ast.CommentInline
-	}
-
-	prefix := func() { b.WriteString("// ") }
-	if jsdoc && cg.Doc && !cg.Line {
-		b.WriteString("/**\n")
-		prefix = func() { b.WriteString(" * ") }
-	} else if jsdoc && !cg.Doc && cg.Line {
-		b.WriteString("//")
-		prefix = func() { b.WriteString(" ") }
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(cg.Text()))
-	var i int
-	for scanner.Scan() {
-		if i != 0 {
-			b.WriteString("\n")
-		}
-		prefix()
-		b.WriteString(scanner.Text())
-		i++
-	}
-	if jsdoc && cg.Doc {
-		b.WriteString("\n")
-		b.WriteString(" */")
-	}
-
-	return ast.Comment{
-		Text: b.String(),
-		Pos:  pos,
-	}
 }

--- a/ts/ts.go
+++ b/ts/ts.go
@@ -147,14 +147,12 @@ func CommentFromCUEGroup(cg *cast.CommentGroup, jsdoc bool) ast.Comment {
 	}
 
 	prefix := func() { b.WriteString("// ") }
-	if jsdoc {
-		b.WriteString("/**")
-		if cg.Line {
-			prefix = func() { b.WriteString(" ") }
-		} else {
-			b.WriteString("\n")
-			prefix = func() { b.WriteString(" * ") }
-		}
+	if jsdoc && cg.Doc && !cg.Line {
+		b.WriteString("/**\n")
+		prefix = func() { b.WriteString(" * ") }
+	} else if jsdoc && !cg.Doc && cg.Line {
+		b.WriteString("//")
+		prefix = func() { b.WriteString(" ") }
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(cg.Text()))
@@ -167,10 +165,8 @@ func CommentFromCUEGroup(cg *cast.CommentGroup, jsdoc bool) ast.Comment {
 		b.WriteString(scanner.Text())
 		i++
 	}
-	if jsdoc {
-		if !cg.Line {
-			b.WriteString("\n")
-		}
+	if jsdoc && cg.Doc {
+		b.WriteString("\n")
 		b.WriteString(" */")
 	}
 


### PR DESCRIPTION
`v.Doc()` function from Cuelang doesn't retrieve inner comments. When it happens, we need to cast the `cue.Value` to `ast.File` and iterate it (We did something similar in thema) to retrieve the missing ones: [code](https://github.com/grafana/cuetsy/compare/fix-inline-comments?expand=1#diff-0d0495ad16c6f603876bbf484c43b549f53d0b33d4cd74c908b0ee95a94369eaR1435-R1440)

Another changes in the PR:
* Merged `commentsFor ` with `commentsForGroup` and use only `commentsFor`.
* Moved comments related of `ts` class to its own one and created its own `Comment` struct.
* ObjectLit was putting commas at the end of each line, so the comma was after the comment instead after the value type. When the value comes from a `KeyValueExpr`, we put the semicolon after the value type: [here](https://github.com/grafana/cuetsy/compare/fix-inline-comments?expand=1#diff-8368b5178ce83d67bb80d84be5998d930f9ec063fd36b2888c685e407784f8ffR111) and [here](https://github.com/grafana/cuetsy/compare/fix-inline-comments?expand=1#diff-8368b5178ce83d67bb80d84be5998d930f9ec063fd36b2888c685e407784f8ffR65-R68).