### PR TITLE
Fix shorthand structs

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/format"
 )
 
@@ -31,7 +32,12 @@ func getKindFor(v cue.Value) (TSType, error) {
 			attr = a
 		}
 	}
+
 	if !found {
+		if t, ok := getKindForField(v); ok {
+			fmt.Println(t)
+			return t, nil
+		}
 		return "", valError(v, "value has no \"@%s\" attribute", attrname)
 	}
 
@@ -44,6 +50,42 @@ func getKindFor(v cue.Value) (TSType, error) {
 		return "", valError(v, "no value for the %q key in @%s attribute", attrKind, attrname)
 	}
 	return TSType(tt), nil
+}
+
+func getKindForField(v cue.Value) (TSType, bool) {
+	if field, ok := v.Source().(*ast.Field); ok {
+		if s, ok := field.Value.(*ast.StructLit); ok {
+			return iterateField(s)
+		}
+	}
+	return "", false
+}
+
+func iterateField(s *ast.StructLit) (TSType, bool) {
+	for _, el := range s.Elts {
+		if field, ok := el.(*ast.Field); ok {
+			if len(field.Attrs) > 0 {
+				return parseStringAttribute(field.Attrs[0].Text), true
+			}
+			if s, ok := field.Value.(*ast.StructLit); ok {
+				return iterateField(s)
+			}
+		}
+	}
+	return "", false
+}
+
+func parseStringAttribute(attr string) TSType {
+	switch attr {
+	case "@cuetsy(kind=\"interface\")":
+		return TypeInterface
+	case "@cuetsy(kind=\"enum\")":
+		return TypeEnum
+	case "@cuetsy(kind=\"type\")":
+		return TypeAlias
+	default:
+		return ""
+	}
 }
 
 func getForceText(v cue.Value) string {

--- a/analyze.go
+++ b/analyze.go
@@ -35,7 +35,6 @@ func getKindFor(v cue.Value) (TSType, error) {
 
 	if !found {
 		if t, ok := getKindForField(v); ok {
-			fmt.Println(t)
 			return t, nil
 		}
 		return "", valError(v, "value has no \"@%s\" attribute", attrname)

--- a/generate_test.go
+++ b/generate_test.go
@@ -44,9 +44,8 @@ func TestGenerateWithImports(t *testing.T) {
 		Name:   "gen",
 		Update: *updateGolden,
 		ToDo: map[string]string{
-			"imports/oneref_verbose":   "Figure out how to disambiguate struct literals from the struct-with-braces-and-one-element case",
-			"imports/struct_shorthand": "Shorthand struct notation is currently unsupported, needs fixing",
-			"imports/inline_comments":  "Inline comments do not appear be retrievable from cue.Value.Doc()",
+			"imports/oneref_verbose":  "Figure out how to disambiguate struct literals from the struct-with-braces-and-one-element case",
+			"imports/inline_comments": "Inline comments do not appear be retrievable from cue.Value.Doc()",
 		},
 	}
 

--- a/testdata/imports/struct_shorthand.txtar
+++ b/testdata/imports/struct_shorthand.txtar
@@ -8,11 +8,25 @@ TwoLevel: NestedDecl: {
     InnerTwo: number
 } @cuetsy(kind="interface")
 
+ThreeLevel: TwoLevel: NestedDecl: {
+    InnerOne: number
+    InnerTwo: number
+} @cuetsy(kind="interface")
+
 -- out/gen --
 
 export interface TwoLevel {
   NestedDecl: {
     InnerOne: number;
     InnerTwo: number;
+  };
+}
+
+export interface ThreeLevel {
+  TwoLevel: {
+    NestedDecl: {
+      InnerOne: number;
+      InnerTwo: number;
+    };
   };
 }


### PR DESCRIPTION
For any reason, cue api doesn't find the attributes when we are using shorthands. To fix that, we need to cast the `cue.Value` into `ast.Field` and find the missing attributes.