### PR TITLE
Return errors instead of panics when something goes wrong

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -99,6 +99,9 @@ func TestGenerate(t *testing.T) {
 				t.Fatal(err)
 			}
 			out, err := cuetsy.Generate(i.Value(), cuetsy.Config{
+				ImportMapper: func(path string) (string, error) {
+					return path, nil
+				},
 				Export: true,
 			})
 			if c.CaseType == ErrorType {

--- a/generator.go
+++ b/generator.go
@@ -1331,7 +1331,7 @@ func valError(v cue.Value, format string, args ...interface{}) error {
 
 	msg := ""
 	if i, ok := s.(*ast.Field); ok {
-		msg = fmt.Sprintf("We found an error in the field '%s:%d:%d'. ", i.Label, s.Pos().Line(), s.Pos().Column())
+		msg = fmt.Sprintf("Found an error in the field '%s:%d:%d'. ", i.Label, s.Pos().Line(), s.Pos().Column())
 	}
 	f := fmt.Sprintf("%sError: %s", msg, format)
 	return errors.Newf(s.Pos(), f, args...)

--- a/generator.go
+++ b/generator.go
@@ -628,7 +628,7 @@ func findExtends(v cue.Value) ([]ts.Expr, cue.Value, error) {
 			}
 			return nil
 		default:
-			return valError(v, "unhandled op type while finding the extends: %s", op.String())
+			return valError(v, "unhandled op type while finding type to extend: %s", op.String())
 		}
 	}
 

--- a/testdata/bad_definition_error.txtar
+++ b/testdata/bad_definition_error.txtar
@@ -16,4 +16,4 @@ package test
     union: #UnionType
 } @cuetsy(kind="interface")
 -- err --
-We found an error in the field 'union:15:5'. Error: no handler for operator: '.' for kind 'struct'
+Found an error in the field 'union:15:5'. Error: no handler for operator: '.' for kind 'struct'

--- a/testdata/bad_definition_error.txtar
+++ b/testdata/bad_definition_error.txtar
@@ -1,0 +1,19 @@
+-- cue --
+package test
+
+#Test: {
+    #Type1: {
+        group: string
+        options?: [...string]
+    }
+    #Type2: {
+        group: string
+        details: {
+            [string]: _
+        }
+    }
+    #UnionType: #Type1 | #Type2
+    union: #UnionType
+} @cuetsy(kind="interface")
+-- err --
+We found an error in the field 'union:15:5'. Error: no handler for operator: '.' for kind 'struct'

--- a/testdata/disjunct_struct_error.txtar
+++ b/testdata/disjunct_struct_error.txtar
@@ -8,4 +8,4 @@ Out: {
 } @cuetsy(kind="interface")
 
 -- err --
-typescript interfaces cannot be constructed from disjunctions
+We found an error in the field 'Out:3:1'. Error: typescript interfaces cannot be constructed from disjunctions

--- a/testdata/disjunct_struct_error.txtar
+++ b/testdata/disjunct_struct_error.txtar
@@ -8,4 +8,4 @@ Out: {
 } @cuetsy(kind="interface")
 
 -- err --
-We found an error in the field 'Out:3:1'. Error: typescript interfaces cannot be constructed from disjunctions
+Found an error in the field 'Out:3:1'. Error: typescript interfaces cannot be constructed from disjunctions

--- a/testdata/mismatch_len_error.txtar
+++ b/testdata/mismatch_len_error.txtar
@@ -2,4 +2,4 @@
 E3: "a" | "b" | "c" @cuetsy(kind="enum",memberNames="a|b")
 
 -- err --
-We found an error in the field 'E3:1:1'. Error: typescript enums and memberNames attributes size doesn't match
+Found an error in the field 'E3:1:1'. Error: typescript enums and memberNames attributes size doesn't match

--- a/testdata/mismatch_len_error.txtar
+++ b/testdata/mismatch_len_error.txtar
@@ -2,4 +2,4 @@
 E3: "a" | "b" | "c" @cuetsy(kind="enum",memberNames="a|b")
 
 -- err --
-typescript enums and memberNames attributes size doesn't match
+We found an error in the field 'E3:1:1'. Error: typescript enums and memberNames attributes size doesn't match

--- a/testdata/nameless_numerics_error.txtar
+++ b/testdata/nameless_numerics_error.txtar
@@ -2,4 +2,4 @@
 ErrNamelessNumerics: 0 | 1 | 2 @cuetsy(kind="enum")
 
 -- err --
-typescript numeric enums may only be generated from memberNames attribute
+We found an error in the field 'ErrNamelessNumerics:1:1'. Error: typescript numeric enums may only be generated from memberNames attribute

--- a/testdata/nameless_numerics_error.txtar
+++ b/testdata/nameless_numerics_error.txtar
@@ -2,4 +2,4 @@
 ErrNamelessNumerics: 0 | 1 | 2 @cuetsy(kind="enum")
 
 -- err --
-We found an error in the field 'ErrNamelessNumerics:1:1'. Error: typescript numeric enums may only be generated from memberNames attribute
+Found an error in the field 'ErrNamelessNumerics:1:1'. Error: typescript numeric enums may only be generated from memberNames attribute

--- a/testdata/struct_enum_error.txtar
+++ b/testdata/struct_enum_error.txtar
@@ -11,4 +11,4 @@ TableCellDisplayMode: {
 } @cuetsy(kind="enum")
 
 -- err --
-We found an error in the field 'TableCellDisplayMode:1:1'. Error: typescript enums may only be generated from concrete strings, or ints with memberNames attribute
+Found an error in the field 'TableCellDisplayMode:1:1'. Error: typescript enums may only be generated from concrete strings, or ints with memberNames attribute

--- a/testdata/struct_enum_error.txtar
+++ b/testdata/struct_enum_error.txtar
@@ -11,4 +11,4 @@ TableCellDisplayMode: {
 } @cuetsy(kind="enum")
 
 -- err --
-typescript enums may only be generated from concrete strings, or ints with memberNames attribute
+We found an error in the field 'TableCellDisplayMode:1:1'. Error: typescript enums may only be generated from concrete strings, or ints with memberNames attribute


### PR DESCRIPTION
Contributes to: https://github.com/grafana/cuetsy/issues/104

It return errors instead of panics when we found a undesired result. All error messages include (if possible) the name of the field that causes the error.