### PR TITLE
Remove replacements

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,13 +12,6 @@ builds:
       - darwin
     binary: cuetsy
     main: ./cmd/cuetsy
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
`replacements` were deleted in the latest `goreleaser` and we cannot generate the version with this.