### PR TITLE
Allow deeper extends

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -580,7 +580,6 @@ func findExtends(v cue.Value) ([]ts.Expr, cue.Value, error) {
 	// generated as literals.
 	baseNolit := v.Context().CompileString("")
 	nolit := v.Context().CompileString("")
-
 	var walkExpr func(v cue.Value) error
 	walkExpr = func(v cue.Value) error {
 		op, dvals := v.Expr()

--- a/generator.go
+++ b/generator.go
@@ -580,6 +580,7 @@ func findExtends(v cue.Value) ([]ts.Expr, cue.Value, error) {
 	// generated as literals.
 	baseNolit := v.Context().CompileString("")
 	nolit := v.Context().CompileString("")
+
 	var walkExpr func(v cue.Value) error
 	walkExpr = func(v cue.Value) error {
 		op, dvals := v.Expr()
@@ -600,6 +601,12 @@ func findExtends(v cue.Value) ([]ts.Expr, cue.Value, error) {
 		case cue.OrOp:
 			return valError(v, "typescript interfaces cannot be constructed from disjunctions")
 		case cue.SelectorOp:
+			deref := cue.Dereference(v)
+			_, dexpr := deref.Expr()
+			if dexpr[len(dexpr)-1].IncompleteKind() == cue.TopKind {
+				return walkExpr(deref)
+			}
+
 			expr, err := refAsInterface(v)
 			if err != nil {
 				return err


### PR DESCRIPTION
When we have complex cue schemas that extends from other cue files, sometimes the extends is missing. Our current loop tries to extract the value when it has a `SelectorOP` and sometimes, the dependency that we are looking for is deeper.

In a simple case, the structs that we have are like:
```cue
[.]  (struct)
├── (struct)
├── "OurExtend"
└── [ref:OurExtend]
    └── (struct) @cuetsy(kind="interface")
```

So dereferencing it, we can extract the value.

But for complex schemas, we can have something like:
```cue
[.]  (struct)
├── []  (struct)
│   └── [ref:composableKinds.DataQuery.lineage.schemas[0]]
│       └── [&]  (struct)
│           ├── (struct)
│           ├── [.]  (struct)
│           │   ├── (struct)
│           │   ├── "#SchemaDef"...
│           │   └── [ref:#SchemaDef]
│           │       └── (struct)
│           └── (struct)
├── "schema"
└── [ref:composableKinds.DataQuery.lineage.schemas[0].schema]
    └── [&]  (struct)
        ├── [&]  (struct)
        │   ├── [.]  (struct)
        │   │   ├── (struct)
        │   │   ├── "OurExtend"
        │   │   └── [ref:OurExtend]
        │   │       └── (struct) @cuetsy(kind="interface")
        │   └── (struct)
        └── _
```

And you can see that our desired extend is inside the dereference. In that case we need to iterate this deference until we find have a schema without the `TopKind`. 
This is important because its our stop condition. If we don't check this `TopKind`, we could continue iterating this schema and we could retrieve extends (if any) from our desired extend 😅. (For example, if `OurExtend` extends from `Foo` and `Bar`, we are going  to retrieve these values instead of `OurExtend`)