### PR TITLE
Generate valid fields for GenerateSingleAST.

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/cuetsy"
 	"github.com/grafana/cuetsy/internal/cuetxtar"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/txtar"
 	"gotest.tools/assert"
 )
@@ -116,6 +117,17 @@ func TestGenerate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateSingleAST(t *testing.T) {
+	ctx := cuecontext.New()
+	v := ctx.CompileString("a: string")
+
+	p, err := cuetsy.GenerateSingleAST("My-Invalid-Name", v, cuetsy.TypeInterface)
+	require.NoError(t, err)
+
+	decl := p.T.String()
+	assert.Equal(t, decl, "export interface MyInvalidName {\n  a: string;\n}")
 }
 
 func loadCases(dir string) ([]Case, error) {

--- a/generate_test.go
+++ b/generate_test.go
@@ -121,13 +121,13 @@ func TestGenerate(t *testing.T) {
 
 func TestGenerateSingleAST(t *testing.T) {
 	ctx := cuecontext.New()
-	v := ctx.CompileString("a: string")
+	v := ctx.CompileString("a: *\"foo\" | string")
 
 	p, err := cuetsy.GenerateSingleAST("My-Invalid-Name", v, cuetsy.TypeInterface)
 	require.NoError(t, err)
 
-	decl := p.T.String()
-	assert.Equal(t, decl, "export interface MyInvalidName {\n  a: string;\n}")
+	assert.Equal(t, "export interface MyInvalidName {\n  a: string;\n}", p.T.String())
+	assert.Equal(t, "export const defaultMyInvalidName: Partial<MyInvalidName> = {\n  a: 'foo',\n};", p.D.String())
 }
 
 func loadCases(dir string) ([]Case, error) {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/matryer/is v1.4.0
 	github.com/rogpeppe/go-internal v1.9.0
+	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.25.0
 	github.com/xlab/treeprint v1.1.0
 	golang.org/x/tools v0.1.12
@@ -17,15 +18,16 @@ require (
 require (
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/proto v1.10.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/proto v1.10.0 h1:pDGyFRVV5RvV+nkBK9iy3q67FBy9Xa7vwrOTE+g5aGw=
 github.com/emicklei/proto v1.10.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=

--- a/ts/ast/ast.go
+++ b/ts/ast/ast.go
@@ -118,6 +118,7 @@ func (i Ident) ident() {}
 func (i Ident) expr()  {}
 func (i Ident) String() string {
 	n := strings.Replace(i.Name, "#", "", -1)
+	n = regexp.MustCompile("[^a-zA-Z0-9_?]").ReplaceAllString(n, "")
 
 	if i.As != "" {
 		return fmt.Sprintf("%s as %s", n, i.As)

--- a/ts/ast/ast_test.go
+++ b/ts/ast/ast_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cuetsy/ts/ast"
 	"github.com/matryer/is"
+	"github.com/stretchr/testify/assert"
 )
 
 func ident(s string) ast.Ident {
@@ -287,6 +288,42 @@ func TestExportNamespace(t *testing.T) {
 		t.Run(nam, func(t *testing.T) {
 			is := is.New(t)
 			is.Equal(item.want, iitem.input.String())
+		})
+	}
+}
+
+func TestFormatIdentNames(t *testing.T) {
+	testCases := []struct {
+		name   string
+		value  string
+		result string
+	}{
+		{
+			name:   "Text with dashes",
+			value:  "Text-With-Dashes",
+			result: "TextWithDashes",
+		},
+		{
+			name:   "Text with underscores",
+			value:  "Text_With_Underscores",
+			result: "Text_With_Underscores",
+		},
+		{
+			name:   "Text with punctuation marks",
+			value:  "Text.with:punctuation;marks",
+			result: "Textwithpunctuationmarks",
+		},
+		{
+			name:   "Text with optional value",
+			value:  "TestWithOptionalValue?",
+			result: "TestWithOptionalValue?",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			i := ident(tc.value)
+			assert.Equal(t, i.String(), tc.result)
 		})
 	}
 }


### PR DESCRIPTION
`GenerateSingleAST` allows to pass the name of the enum/interface/type directly and it doesn't have any kind of check.

So we can produce invalid TS interfaces adding non-valid characters. I left `_` since is valid in TS and `?` for optionals.